### PR TITLE
Anchor to version 6.9.0 otherwise version 7 is installed

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -25,10 +25,7 @@ jobs:
             8.0
       - run: dotnet test
       - name: Build
-        uses: DEFRA/cdp-build-action/build@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          push: false
+        uses: DEFRA/cdp-build-action/check-pr@main
   sonarcloud-scan:
     name: CDP SonarCloud Scan
     uses: ./.github/workflows/sonarcloud.yml

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -24,6 +24,11 @@ jobs:
           dotnet-version: |
             8.0
       - run: dotnet test
+      - name: Build
+        uses: DEFRA/cdp-build-action/build@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push: false
   sonarcloud-scan:
     name: CDP SonarCloud Scan
     uses: ./.github/workflows/sonarcloud.yml

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -24,7 +24,7 @@ jobs:
           dotnet-version: |
             8.0
       - run: dotnet test
-      - name: Build
+      - name: Docker
         uses: DEFRA/cdp-build-action/check-pr@main
   sonarcloud-scan:
     name: CDP SonarCloud Scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /src
 
 ENV PATH="$PATH:/root/.dotnet/tools"
 RUN dotnet tool install -g csharpier && \
-    dotnet tool install -g Swashbuckle.AspNetCore.Cli
+    dotnet tool install -g Swashbuckle.AspNetCore.Cli --version 6.9.0
  
 COPY .csharpierrc .csharpierrc
 COPY .vacuum.yml .vacuum.yml


### PR DESCRIPTION
As our solution template currently references version 6.9.0, we need to ensure the same version of the CLI tools are installed when building the container.

As now main cannot build and push.

~Do we have the ability to run a `docker build` as part of the PR checks?~

A check PR docker build step has now been included in our PR workflow.