### PR TITLE
Drop old Swashbuckle CLI version now that we're on version 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /src
 
 ENV PATH="$PATH:/root/.dotnet/tools"
 RUN dotnet tool install -g csharpier && \
-    dotnet tool install -g Swashbuckle.AspNetCore.Cli --version 6.9.0
+    dotnet tool install -g Swashbuckle.AspNetCore.Cli
  
 COPY .csharpierrc .csharpierrc
 COPY .vacuum.yml .vacuum.yml

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 dependencies:
-	dotnet tool install -g Swashbuckle.AspNetCore.Cli --version 6.9.0
+	dotnet tool install -g Swashbuckle.AspNetCore.Cli
 
 lint-openapi-spec: dependencies
 	dotnet build -c Release --no-restore


### PR DESCRIPTION
As per PR title.

This was missed in the previous package update PR https://github.com/DEFRA/pha-import-notifications/pull/17.