### PR TITLE
Update to dotnet 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ﻿# Base dotnet image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
@@ -12,7 +12,7 @@ RUN apt update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 
 ARG VACUUM_VERSION=0.14.2
 WORKDIR /tmp/vacuum

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,13 @@ WORKDIR /tmp/vacuum
 RUN wget "https://github.com/daveshanley/vacuum/releases/download/v${VACUUM_VERSION}/vacuum_${VACUUM_VERSION}_linux_x86_64.tar.gz" -q -O vacuum.tar.gz && \
     tar zxvf "vacuum.tar.gz" && \
     mv vacuum /usr/bin/vacuum
- 
+
 WORKDIR /src
 
 ENV PATH="$PATH:/root/.dotnet/tools"
-RUN dotnet tool install -g csharpier && \
+RUN dotnet tool install -g --allow-roll-forward csharpier && \
     dotnet tool install -g Swashbuckle.AspNetCore.Cli
- 
+
 COPY .csharpierrc .csharpierrc
 COPY .vacuum.yml .vacuum.yml
 
@@ -41,10 +41,10 @@ COPY src/Api src/Api
 COPY tests/Api.Tests tests/Api.Tests
 COPY tests/Api.IntegrationTests tests/Api.IntegrationTests
 
-RUN dotnet csharpier --check . 
+RUN dotnet csharpier --check .
 
 RUN dotnet build --no-restore -c Release
-RUN swagger tofile --output openapi.json ./src/Api/bin/Release/net8.0/Defra.PhaImportNotifications.Api.dll v1
+RUN swagger tofile --output openapi.json ./src/Api/bin/Release/net9.0/Defra.PhaImportNotifications.Api.dll v1
 RUN vacuum lint -d -r .vacuum.yml openapi.json
 
 RUN dotnet test --no-restore tests/Api.Tests

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>Defra.PhaImportNotifications.Api</AssemblyName>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/src/Api/Utils/TrustStore.cs
+++ b/src/Api/Utils/TrustStore.cs
@@ -37,7 +37,9 @@ public static class TrustStore
     {
         if (certificates.Count == 0)
             return; // to stop trust store access denied issues on Macs
-        var x509Certificate2S = certificates.Select(cert => new X509Certificate2(Encoding.ASCII.GetBytes(cert)));
+        var x509Certificate2S = certificates.Select(cert =>
+            X509CertificateLoader.LoadCertificate(Encoding.ASCII.GetBytes(cert))
+        );
         var certificateCollection = new X509Certificate2Collection();
 
         foreach (var certificate2 in x509Certificate2S)

--- a/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
+++ b/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
     <AssemblyName>Defra.PhaImportNotifications.Api.IntegrationTests</AssemblyName>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/tests/Api.Tests/Api.Tests.csproj
+++ b/tests/Api.Tests/Api.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
     <AssemblyName>Defra.PhaImportNotifications.Api.Tests</AssemblyName>
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />


### PR DESCRIPTION
As per PR title.

Only change of note was needing to add `--allow-roll-forward` to the csharpier install within the Dockerfile. Official dotnet 9 support for csharpier is almost ready for release.

You will obviously need the dotnet 9 SDK locally.

Added a `global.json` file to set the SDK version that the dotnet command should use.