### PR TITLE
PHAIN-33: Fix SonarCloud warning

### DIFF
--- a/src/Api/SwashbuckleFilters/AddSwashbuckleHeaders.cs
+++ b/src/Api/SwashbuckleFilters/AddSwashbuckleHeaders.cs
@@ -19,7 +19,7 @@ public class AddSwashbuckleHeaders : IOperationFilter
         if (actionAttributes == null || !actionAttributes.Any())
             return;
 
-        foreach (var (statusCode, response) in operation.Responses)
+        foreach (var (statusCode, _) in operation.Responses)
         {
             operation
                 .Responses[statusCode]


### PR DESCRIPTION
This parameter was not being used and caused SonarCloud to throw a warning.