### PR TITLE
PHAIN-68: Improve OpenApi specification

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "swashbuckle.aspnetcore.cli": {
+      "version": "7.1.0",
+      "commands": [
+        "swagger"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 dependencies:
-	dotnet tool install -g Swashbuckle.AspNetCore.Cli
+	dotnet tool restore
 
 generate-openapi-spec: dependencies
 	dotnet build -c Release --no-restore

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/Api/Endpoints/ImportNotificationsUpdatesEndpoints.cs
+++ b/src/Api/Endpoints/ImportNotificationsUpdatesEndpoints.cs
@@ -14,7 +14,7 @@ public static class ImportNotificationsUpdatesEndpoints
 
         app.MapGet("import-notifications-updates/{portHealthAuthority}/", Get)
             .WithName("ImportNotificationsUpdatesByReferenceNumber")
-            .WithTags("Import Notifications Updates")
+            .WithTags("Import Notifications")
             .WithSummary("Get Import Notification Updates")
             .WithDescription(
                 "Get all import notifications by port health authority that have been updated between the time period specified"

--- a/src/Api/Endpoints/PagedResponse.cs
+++ b/src/Api/Endpoints/PagedResponse.cs
@@ -1,18 +1,23 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace Defra.PhaImportNotifications.Api.Endpoints;
 
 internal sealed class PagedResponse<T>
 {
     [Description("Records for current page")]
+    [Required]
     public IEnumerable<T> Records { get; init; } = [];
 
     [Description("Total records across all pages")]
+    [Required]
     public int TotalRecords { get; init; }
 
     [Description("Current page")]
+    [Required]
     public int CurrentPage { get; init; }
 
     [Description("Total number of pages")]
+    [Required]
     public int TotalPages { get; init; }
 }

--- a/src/Api/Endpoints/UpdatedImportNotification.cs
+++ b/src/Api/Endpoints/UpdatedImportNotification.cs
@@ -1,12 +1,16 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace Defra.PhaImportNotifications.Api.Endpoints;
 
 internal sealed class UpdatedImportNotification
 {
     [Description("Last updated date. Format is ISO 8601-1:2019")]
+    [Required]
     public DateTime LastUpdated { get; init; }
 
+    /// <example>/import-notifications/referenceNumber</example>
     [Description("Relative path to import notification")]
+    [Required]
     public required Uri Uri { get; init; }
 }

--- a/src/Api/OpenApi/TagsDocumentFilter.cs
+++ b/src/Api/OpenApi/TagsDocumentFilter.cs
@@ -1,0 +1,31 @@
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Defra.PhaImportNotifications.Api.OpenApi;
+
+public class TagsDocumentFilter : IDocumentFilter
+{
+    private const string ImportNotificationsTag = "Import Notifications";
+
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        swaggerDoc.Extensions["tags"] = new OpenApiArray
+        {
+            new OpenApiObject
+            {
+                ["name"] = new OpenApiString(ImportNotificationsTag),
+                ["description"] = new OpenApiString("Get updated import notifications for a PHA"),
+            },
+        };
+
+        swaggerDoc.Extensions["x-tagGroups"] = new OpenApiArray
+        {
+            new OpenApiObject
+            {
+                ["name"] = new OpenApiString("Endpoints"),
+                ["tags"] = new OpenApiArray { new OpenApiString(ImportNotificationsTag) },
+            },
+        };
+    }
+}

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -93,7 +93,7 @@
     /import-notifications-updates/{portHealthAuthority}: {
       get: {
         tags: [
-          Import Notifications Updates
+          Import Notifications
         ],
         summary: Get Import Notification Updates,
         description: Get all import notifications by port health authority that have been updated between the time period specified,
@@ -3128,6 +3128,7 @@
       },
       UpdatedImportNotification: {
         required: [
+          lastUpdated,
           uri
         ],
         type: object,
@@ -3141,12 +3142,18 @@
             type: string,
             description: Relative path to import notification,
             format: uri,
-            nullable: true
+            example: /import-notifications/referenceNumber
           }
         },
         additionalProperties: false
       },
       UpdatedImportNotificationPagedResponse: {
+        required: [
+          currentPage,
+          records,
+          totalPages,
+          totalRecords
+        ],
         type: object,
         properties: {
           records: {
@@ -3154,8 +3161,7 @@
             items: {
               $ref: #/components/schemas/UpdatedImportNotification
             },
-            description: Records for current page,
-            nullable: true
+            description: Records for current page
           },
           totalRecords: {
             type: integer,
@@ -3271,5 +3277,19 @@
         additionalProperties: false
       }
     }
-  }
+  },
+  tags: [
+    {
+      name: Import Notifications,
+      description: Get updated import notifications for a PHA
+    }
+  ],
+  x-tagGroups: [
+    {
+      name: Endpoints,
+      tags: [
+        Import Notifications
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This change:
- Adds required fields to the response body for updated import notifications to no longer be nullable.
- Groups together the two endpoints under an "Endpoints" title.
- Tweaks a couple of other OpenApi bits.
- Moves the OpenApi spec generator to a tool manifest to remove the need to install it globally.