### PR TITLE
Ignore fields from BTMS that we do not want to expose in our PHA contract

### DIFF
--- a/src/Contracts/CommodityRiskResult.g.cs
+++ b/src/Contracts/CommodityRiskResult.g.cs
@@ -36,10 +36,12 @@ public class CommodityRiskResult
     public string? Variety { get; init; }
 
     [JsonPropertyName("isWoody")]
+    [JsonIgnore]
     [Description("Whether or not a plant is woody")]
     public bool? IsWoody { get; init; }
 
     [JsonPropertyName("indoorOutdoor")]
+    [JsonIgnore]
     [Description("Indoor or Outdoor for a plant")]
     public string? IndoorOutdoor { get; init; }
 

--- a/src/Contracts/ComplementParameterSet.g.cs
+++ b/src/Contracts/ComplementParameterSet.g.cs
@@ -19,6 +19,7 @@ public class ComplementParameterSet
     public object? KeyDataPairs { get; init; }
 
     [JsonPropertyName("catchCertificates")]
+    [JsonIgnore]
     [Description("Catch certificate details")]
     public List<CatchCertificates>? CatchCertificates { get; init; }
 

--- a/src/Contracts/ControlAuthority.g.cs
+++ b/src/Contracts/ControlAuthority.g.cs
@@ -21,6 +21,7 @@ public class ControlAuthority
     public string? NewSealNumber { get; init; }
 
     [JsonPropertyName("iuuFishingReference")]
+    [JsonIgnore]
     [Description("Illegal, Unreported and Unregulated (IUU) fishing reference number")]
     public string? IuuFishingReference { get; init; }
 

--- a/src/Contracts/ImportNotification.g.cs
+++ b/src/Contracts/ImportNotification.g.cs
@@ -5,26 +5,51 @@ using System.ComponentModel;
 namespace Defra.PhaImportNotifications.Contracts;
 public class ImportNotification
 {
+    [JsonPropertyName("_Etag")]
+    [JsonIgnore]
+    public string? _Etag { get; init; }
+
     [JsonPropertyName("createdSource")]
+    [Description("Date when the notification was created in IPAFFS")]
     public DateTime? CreatedSource { get; init; }
 
     [JsonPropertyName("created")]
+    [Description("Date when the notification was created")]
     public required DateTime Created { get; init; }
 
     [JsonPropertyName("updated")]
+    [Description("Date when the notification was last updated")]
     public required DateTime Updated { get; init; }
 
     [JsonPropertyName("auditEntries")]
+    [JsonIgnore]
     public List<AuditEntry>? AuditEntries { get; init; }
 
     [JsonPropertyName("relationships")]
-    public required NotificationTdmRelationships Relationships { get; init; }
+    [JsonIgnore]
+    public NotificationTdmRelationships? Relationships { get; init; }
 
     [JsonPropertyName("commoditiesSummary")]
     public required Commodities CommoditiesSummary { get; init; }
 
     [JsonPropertyName("commodities")]
     public List<CommodityComplement>? Commodities { get; init; }
+
+    [JsonPropertyName("_Ts")]
+    [JsonIgnore]
+    public DateTime? _Ts { get; init; }
+
+    [JsonPropertyName("_PointOfEntry")]
+    [JsonIgnore]
+    public string? _PointOfEntry { get; init; }
+
+    [JsonPropertyName("_PointOfEntryControlPoint")]
+    [JsonIgnore]
+    public string? _PointOfEntryControlPoint { get; init; }
+
+    [JsonPropertyName("_MatchReference")]
+    [JsonIgnore]
+    public string? _MatchReference { get; init; }
 
     [JsonPropertyName("ipaffsId")]
     [Description("The IPAFFS ID number for this notification.")]
@@ -47,7 +72,7 @@ public class ImportNotification
     public int? Version { get; init; }
 
     [JsonPropertyName("updatedSource")]
-    [Description("Date when the notification was last updated.")]
+    [Description("Date when the notification was last updated in IPAFFS")]
     public DateTime? UpdatedSource { get; init; }
 
     [JsonPropertyName("lastUpdatedBy")]
@@ -121,6 +146,7 @@ public class ImportNotification
     public bool? IsRiskDecisionLocked { get; init; }
 
     [JsonPropertyName("isBulkUploadInProgress")]
+    [JsonIgnore]
     [Description("Boolean flag that indicates whether a bulk upload is in progress")]
     public bool? IsBulkUploadInProgress { get; init; }
 

--- a/src/Contracts/PartOne.g.cs
+++ b/src/Contracts/PartOne.g.cs
@@ -6,16 +6,19 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class PartOne
 {
     [JsonPropertyName("typeOfImp")]
-    public required PartOneTypeOfImpEnum TypeOfImp { get; init; }
+    [JsonIgnore]
+    public PartOneTypeOfImpEnum? TypeOfImp { get; init; }
 
     [JsonPropertyName("personResponsible")]
     public required Party PersonResponsible { get; init; }
 
     [JsonPropertyName("customsReferenceNumber")]
+    [JsonIgnore]
     [Description("Customs reference number")]
     public string? CustomsReferenceNumber { get; init; }
 
     [JsonPropertyName("containsWoodPackaging")]
+    [JsonIgnore]
     [Description("(Deprecated in IMTA-11832) Does the consignment contain wood packaging?")]
     public bool? ContainsWoodPackaging { get; init; }
 
@@ -27,7 +30,8 @@ public class PartOne
     public required EconomicOperator Consignor { get; init; }
 
     [JsonPropertyName("consignorTwo")]
-    public required EconomicOperator ConsignorTwo { get; init; }
+    [JsonIgnore]
+    public EconomicOperator? ConsignorTwo { get; init; }
 
     [JsonPropertyName("packer")]
     public required EconomicOperator Packer { get; init; }
@@ -45,9 +49,11 @@ public class PartOne
     public required EconomicOperator Pod { get; init; }
 
     [JsonPropertyName("placeOfOriginHarvest")]
-    public required EconomicOperator PlaceOfOriginHarvest { get; init; }
+    [JsonIgnore]
+    public EconomicOperator? PlaceOfOriginHarvest { get; init; }
 
     [JsonPropertyName("additionalPermanentAddresses")]
+    [JsonIgnore]
     [Description("List of additional permanent addresses")]
     public List<EconomicOperator>? AdditionalPermanentAddresses { get; init; }
 
@@ -56,10 +62,12 @@ public class PartOne
     public string? CphNumber { get; init; }
 
     [JsonPropertyName("importingFromCharity")]
+    [JsonIgnore]
     [Description("Is the importer importing from a charity?")]
     public bool? ImportingFromCharity { get; init; }
 
     [JsonPropertyName("isPlaceOfDestinationThePermanentAddress")]
+    [JsonIgnore]
     [Description("Is the place of destination the permanent address?")]
     public bool? IsPlaceOfDestinationThePermanentAddress { get; init; }
 
@@ -100,6 +108,7 @@ public class PartOne
     public decimal? EstimatedJourneyTimeInMinutes { get; init; }
 
     [JsonPropertyName("responsibleForTransport")]
+    [JsonIgnore]
     [Description("(Deprecated in IMTA-12139) Person who is responsible for transport")]
     public string? ResponsibleForTransport { get; init; }
 
@@ -114,6 +123,7 @@ public class PartOne
     public required Route Route { get; init; }
 
     [JsonPropertyName("sealsContainers")]
+    [JsonIgnore]
     [Description("Array that contains pair of seal number and container number")]
     public List<SealContainer>? SealsContainers { get; init; }
 
@@ -129,6 +139,7 @@ public class PartOne
     public List<ValidationMessageCode>? ConsignmentValidations { get; init; }
 
     [JsonPropertyName("complexCommoditySelected")]
+    [JsonIgnore]
     [Description("Was complex commodity selected. Indicating if importer provided commodity code.")]
     public bool? ComplexCommoditySelected { get; init; }
 

--- a/src/Contracts/PartTwo.g.cs
+++ b/src/Contracts/PartTwo.g.cs
@@ -26,6 +26,7 @@ public class PartTwo
     public bool? ResealedContainersIncluded { get; init; }
 
     [JsonPropertyName("resealedContainers")]
+    [JsonIgnore]
     [Description("(Deprecated - To be removed as part of IMTA-6256) Resealed containers information details")]
     public List<string>? ResealedContainers { get; init; }
 

--- a/src/Contracts/VeterinaryInformation.g.cs
+++ b/src/Contracts/VeterinaryInformation.g.cs
@@ -33,6 +33,7 @@ public class VeterinaryInformation
     public List<CatchCertificateAttachment>? CatchCertificateAttachments { get; init; }
 
     [JsonPropertyName("identificationDetails")]
+    [JsonIgnore]
     [Description("Details helpful for identification")]
     public List<IdentificationDetails>? IdentificationDetails { get; init; }
 }

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -495,65 +495,6 @@
         },
         additionalProperties: false
       },
-      AuditDiffEntry: {
-        type: object,
-        properties: {
-          path: {
-            type: string,
-            nullable: true
-          },
-          op: {
-            type: string,
-            nullable: true
-          },
-          value: {
-            nullable: true
-          }
-        },
-        additionalProperties: false
-      },
-      AuditEntry: {
-        required: [
-          createdLocal,
-          version
-        ],
-        type: object,
-        properties: {
-          id: {
-            type: string,
-            nullable: true
-          },
-          version: {
-            type: integer,
-            format: int32
-          },
-          createdBy: {
-            type: string,
-            nullable: true
-          },
-          createdSource: {
-            type: string,
-            format: date-time,
-            nullable: true
-          },
-          createdLocal: {
-            type: string,
-            format: date-time
-          },
-          status: {
-            type: string,
-            nullable: true
-          },
-          diff: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/AuditDiffEntry
-            },
-            nullable: true
-          }
-        },
-        additionalProperties: false
-      },
       BillingInformation: {
         required: [
           postalAddress
@@ -967,16 +908,6 @@
             description: Name or ID of the variety,
             nullable: true
           },
-          isWoody: {
-            type: boolean,
-            description: Whether or not a plant is woody,
-            nullable: true
-          },
-          indoorOutdoor: {
-            type: string,
-            description: Indoor or Outdoor for a plant,
-            nullable: true
-          },
           propagation: {
             type: string,
             description: Whether the propagation is considered a Plant, Bulb, Seed or None,
@@ -1221,11 +1152,6 @@
           newSealNumber: {
             type: string,
             description: When the containers are resealed they need new seal numbers,
-            nullable: true
-          },
-          iuuFishingReference: {
-            type: string,
-            description: Illegal, Unreported and Unregulated (IUU) fishing reference number,
             nullable: true
           },
           iuuCheckRequired: {
@@ -1783,22 +1709,6 @@
         ],
         type: string
       },
-      IdentificationDetails: {
-        type: object,
-        properties: {
-          identificationDetail: {
-            type: string,
-            description: Identification detail,
-            nullable: true
-          },
-          identificationDescription: {
-            type: string,
-            description: Identification description,
-            nullable: true
-          }
-        },
-        additionalProperties: false
-      },
       ImpactOfTransportOnAnimals: {
         type: object,
         properties: {
@@ -1871,7 +1781,6 @@
           partOne,
           partThree,
           partTwo,
-          relationships,
           riskAssessment,
           splitConsignment,
           status,
@@ -1881,26 +1790,19 @@
         properties: {
           createdSource: {
             type: string,
+            description: Date when the notification was created in IPAFFS,
             format: date-time,
             nullable: true
           },
           created: {
             type: string,
+            description: Date when the notification was created,
             format: date-time
           },
           updated: {
             type: string,
+            description: Date when the notification was last updated,
             format: date-time
-          },
-          auditEntries: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/AuditEntry
-            },
-            nullable: true
-          },
-          relationships: {
-            $ref: #/components/schemas/NotificationTdmRelationships
           },
           commoditiesSummary: {
             $ref: #/components/schemas/Commodities
@@ -1944,7 +1846,7 @@
           },
           updatedSource: {
             type: string,
-            description: Date when the notification was last updated.,
+            description: Date when the notification was last updated in IPAFFS,
             format: date-time,
             nullable: true
           },
@@ -2030,11 +1932,6 @@
           isRiskDecisionLocked: {
             type: boolean,
             description: is the risk decision locked?,
-            nullable: true
-          },
-          isBulkUploadInProgress: {
-            type: boolean,
-            description: Boolean flag that indicates whether a bulk upload is in progress,
             nullable: true
           },
           requestId: {
@@ -2356,18 +2253,6 @@
         },
         additionalProperties: false
       },
-      NotificationTdmRelationships: {
-        required: [
-          movements
-        ],
-        type: object,
-        properties: {
-          movements: {
-            $ref: #/components/schemas/TdmRelationshipObject
-          }
-        },
-        additionalProperties: false
-      },
       OfficialInspector: {
         required: [
           address
@@ -2452,7 +2337,6 @@
           commonUserCharge,
           consignee,
           consignor,
-          consignorTwo,
           contactDetails,
           importer,
           meansOfTransport,
@@ -2460,33 +2344,18 @@
           packer,
           personResponsible,
           placeOfDestination,
-          placeOfOriginHarvest,
           pod,
           provideCtcMrn,
           purpose,
           route,
           submittedBy,
           transporter,
-          typeOfImp,
           veterinaryInformation
         ],
         type: object,
         properties: {
-          typeOfImp: {
-            $ref: #/components/schemas/PartOneTypeOfImpEnum
-          },
           personResponsible: {
             $ref: #/components/schemas/Party
-          },
-          customsReferenceNumber: {
-            type: string,
-            description: Customs reference number,
-            nullable: true
-          },
-          containsWoodPackaging: {
-            type: boolean,
-            description: (Deprecated in IMTA-11832) Does the consignment contain wood packaging?,
-            nullable: true
           },
           consignmentArrived: {
             type: boolean,
@@ -2494,9 +2363,6 @@
             nullable: true
           },
           consignor: {
-            $ref: #/components/schemas/EconomicOperator
-          },
-          consignorTwo: {
             $ref: #/components/schemas/EconomicOperator
           },
           packer: {
@@ -2514,30 +2380,9 @@
           pod: {
             $ref: #/components/schemas/EconomicOperator
           },
-          placeOfOriginHarvest: {
-            $ref: #/components/schemas/EconomicOperator
-          },
-          additionalPermanentAddresses: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/EconomicOperator
-            },
-            description: List of additional permanent addresses,
-            nullable: true
-          },
           cphNumber: {
             type: string,
             description: Charity Parish Holding number,
-            nullable: true
-          },
-          importingFromCharity: {
-            type: boolean,
-            description: Is the importer importing from a charity?,
-            nullable: true
-          },
-          isPlaceOfDestinationThePermanentAddress: {
-            type: boolean,
-            description: Is the place of destination the permanent address?,
             nullable: true
           },
           isCatchCertificateRequired: {
@@ -2583,11 +2428,6 @@
             format: double,
             nullable: true
           },
-          responsibleForTransport: {
-            type: string,
-            description: (Deprecated in IMTA-12139) Person who is responsible for transport,
-            nullable: true
-          },
           veterinaryInformation: {
             $ref: #/components/schemas/VeterinaryInformation
           },
@@ -2598,14 +2438,6 @@
           },
           route: {
             $ref: #/components/schemas/Route
-          },
-          sealsContainers: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/SealContainer
-            },
-            description: Array that contains pair of seal number and container number,
-            nullable: true
           },
           submittedOn: {
             type: string,
@@ -2622,11 +2454,6 @@
               $ref: #/components/schemas/ValidationMessageCode
             },
             description: Validation messages for whole notification,
-            nullable: true
-          },
-          complexCommoditySelected: {
-            type: boolean,
-            description: Was complex commodity selected. Indicating if importer provided commodity code.,
             nullable: true
           },
           portOfEntry: {
@@ -2701,14 +2528,6 @@
           Yes,
           YesAddLater,
           No
-        ],
-        type: string
-      },
-      PartOneTypeOfImpEnum: {
-        enum: [
-          A,
-          P,
-          D
         ],
         type: string
       },
@@ -2788,14 +2607,6 @@
           resealedContainersIncluded: {
             type: boolean,
             description: Are the containers resealed,
-            nullable: true
-          },
-          resealedContainers: {
-            type: array,
-            items: {
-              type: string
-            },
-            description: (Deprecated - To be removed as part of IMTA-6256) Resealed containers information details,
             nullable: true
           },
           resealedContainersMappings: {
@@ -3199,69 +3010,6 @@
         ],
         type: string
       },
-      RelationshipDataItem: {
-        required: [
-          links
-        ],
-        type: object,
-        properties: {
-          matched: {
-            type: boolean,
-            nullable: true
-          },
-          type: {
-            type: string,
-            nullable: true
-          },
-          id: {
-            type: string,
-            nullable: true
-          },
-          links: {
-            $ref: #/components/schemas/ResourceLink
-          },
-          sourceItem: {
-            type: integer,
-            format: int32,
-            nullable: true
-          },
-          destinationItem: {
-            type: integer,
-            format: int32,
-            nullable: true
-          },
-          matchingLevel: {
-            type: integer,
-            format: int32,
-            nullable: true
-          }
-        },
-        additionalProperties: false
-      },
-      RelationshipLinks: {
-        type: object,
-        properties: {
-          self: {
-            type: string,
-            nullable: true
-          },
-          related: {
-            type: string,
-            nullable: true
-          }
-        },
-        additionalProperties: false
-      },
-      ResourceLink: {
-        type: object,
-        properties: {
-          self: {
-            type: string,
-            nullable: true
-          }
-        },
-        additionalProperties: false
-      },
       RiskAssessmentResult: {
         type: object,
         properties: {
@@ -3394,29 +3142,6 @@
           rejectedReferenceNumber: {
             type: string,
             description: Reference number of the rejected split consignment,
-            nullable: true
-          }
-        },
-        additionalProperties: false
-      },
-      TdmRelationshipObject: {
-        required: [
-          links
-        ],
-        type: object,
-        properties: {
-          matched: {
-            type: boolean,
-            nullable: true
-          },
-          links: {
-            $ref: #/components/schemas/RelationshipLinks
-          },
-          data: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/RelationshipDataItem
-            },
             nullable: true
           }
         },
@@ -3564,14 +3289,6 @@
               $ref: #/components/schemas/CatchCertificateAttachment
             },
             description: Catch certificate attachments,
-            nullable: true
-          },
-          identificationDetails: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/IdentificationDetails
-            },
-            description: Details helpful for identification,
             nullable: true
           }
         },

--- a/tools/SchemaToCSharp/Ignored.cs
+++ b/tools/SchemaToCSharp/Ignored.cs
@@ -1,0 +1,59 @@
+namespace SchemaToCSharp;
+
+internal static class Ignored
+{
+    public static readonly Dictionary<string, HashSet<string>> Properties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        {
+            "ImportNotification",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "_Etag",
+                "_Ts",
+                "_PointOfEntry",
+                "_PointOfEntryControlPoint",
+                "_MatchReference",
+                "AuditEntries",
+                "Relationships",
+                "IsBulkUploadInProgress",
+            }
+        },
+        {
+            "PartOne",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "TypeOfImp",
+                "CustomsReferenceNumber",
+                "ContainsWoodPackaging",
+                "ConsignorTwo",
+                "PlaceOfOriginHarvest",
+                "AdditionalPermanentAddresses",
+                "ImportingFromCharity",
+                "IsPlaceOfDestinationThePermanentAddress",
+                "ResponsibleForTransport",
+                "SealsContainers",
+                "ComplexCommoditySelected",
+            }
+        },
+        {
+            "PartTwo",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ResealedContainers" }
+        },
+        {
+            "VeterinaryInformation",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "IdentificationDetails" }
+        },
+        {
+            "ComplementParameterSet",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CatchCertificates" }
+        },
+        {
+            "CommodityRiskResult",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "IsWoody", "IndoorOutdoor" }
+        },
+        {
+            "ControlAuthority",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "IuuFishingReference" }
+        },
+    };
+}

--- a/tools/SchemaToCSharp/Meta.cs
+++ b/tools/SchemaToCSharp/Meta.cs
@@ -1,0 +1,20 @@
+namespace SchemaToCSharp;
+
+internal static class Meta
+{
+    public static readonly Dictionary<string, Dictionary<string, string>> Descriptions = new(
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        {
+            "ImportNotification",
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "Created", "Date when the notification was created" },
+                { "Updated", "Date when the notification was last updated" },
+                { "CreatedSource", "Date when the notification was created in IPAFFS" },
+                { "UpdatedSource", "Date when the notification was last updated in IPAFFS" },
+            }
+        },
+    };
+}

--- a/tools/SchemaToCSharp/Program.cs
+++ b/tools/SchemaToCSharp/Program.cs
@@ -16,6 +16,8 @@ const string solutionPath = "../../../../../";
 const string outputPath = $"{solutionPath}src/Contracts/";
 const string inputPath = $"{solutionPath}tools/SchemaToCSharp/cdms-public-openapi-v0.1.json";
 
+Directory.GetFiles(outputPath, "*.cs").ToList().ForEach(File.Delete);
+
 var stream = new FileStream(inputPath, FileMode.Open);
 var openApiDocument = new OpenApiStreamReader().Read(stream, out _);
 

--- a/tools/SchemaToCSharp/Program.cs
+++ b/tools/SchemaToCSharp/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
+using SchemaToCSharp;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 #pragma warning disable CS8321 // Local function is declared but never used
@@ -46,10 +47,7 @@ foreach (var (schemaName, schema) in openApiDocument.Components.Schemas)
 
     SyntaxNode CreateClassSyntax()
     {
-        var properties = schema
-            .Properties.Where(p => !p.Key.StartsWith('_'))
-            .Select(p => CreateProperty(p.Key, p.Value));
-
+        var properties = schema.Properties.Select(p => CreateProperty(schemaName, p.Key, p.Value));
         var @class = CreateClass(schemaName).AddMembers(properties.ToArray<MemberDeclarationSyntax>());
 
         return CompilationUnit()
@@ -83,12 +81,13 @@ static string RefTypeName(OpenApiSchema schema, string defaultTypeName) =>
 
 static EnumMemberDeclarationSyntax CreateEnumValue(string name) => EnumMemberDeclaration(name);
 
-static PropertyDeclarationSyntax CreateProperty(string name, OpenApiSchema schema)
+static PropertyDeclarationSyntax CreateProperty(string schemaName, string name, OpenApiSchema schema)
 {
     var typeSyntax = CreatePropertyType(schema);
     var modifiers = new List<SyntaxToken> { Token(SyntaxKind.PublicKeyword) };
+    var ignored = Ignored.Properties.TryGetValue(schemaName, out var properties) && properties.Contains(name);
 
-    if (schema.Nullable)
+    if (schema.Nullable || ignored)
     {
         typeSyntax = NullableType(typeSyntax);
     }
@@ -99,7 +98,19 @@ static PropertyDeclarationSyntax CreateProperty(string name, OpenApiSchema schem
 
     var attributes = new List<AttributeListSyntax> { CreateSimpleAttributeList("JsonPropertyName", name) };
 
-    var description = schema.Description;
+    if (ignored)
+        attributes.Add(AttributeList(SingletonSeparatedList(Attribute(ParseName("JsonIgnore")))));
+
+    if (
+        !(
+            Meta.Descriptions.TryGetValue(schemaName, out var descriptions)
+            && descriptions.TryGetValue(name, out var description)
+        )
+    )
+    {
+        description = schema.Description;
+    }
+
     if (!string.IsNullOrEmpty(description))
         attributes.Add(CreateSimpleAttributeList("Description", description));
 


### PR DESCRIPTION
This PR adds the ability to ignore fields during our schema generation.

It also allows description text to be overridden for fields.

The main point of discussion is the `CreatedSource` and `UpdatedSource` fields on an `ImportNotification`. There are additional `Created` and `Updated` fields from BTMS. As it stands, all 4 fields are being returned. We most likely want one of the pairs but this could involve field mapping, which should be discussed first.

I have also removed the auto exclusion of a field if it starts with an underscore. And replaced it with explicit ignores so we have the fields if we need them but they are not included in our public response.