### PR TITLE
PHAIN-80: Add Basic auth for BTMS

### DIFF
--- a/src/Api/Configuration/BtmsOptions.cs
+++ b/src/Api/Configuration/BtmsOptions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text;
 
 namespace Defra.PhaImportNotifications.Api.Configuration;
 
@@ -6,4 +7,12 @@ public class BtmsOptions
 {
     [Required]
     public required string BaseUrl { get; init; }
+
+    [Required]
+    public required string Username { get; init; }
+
+    [Required]
+    public required string Password { get; init; }
+
+    public string BasicAuthCredential => Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"));
 }

--- a/src/Api/JsonApi/ServiceCollectionExtensions.cs
+++ b/src/Api/JsonApi/ServiceCollectionExtensions.cs
@@ -7,7 +7,8 @@ public static class ServiceCollectionExtensions
 {
     public static IHttpClientBuilder AddJsonApiClient(
         this IServiceCollection services,
-        Func<IServiceProvider, string> baseUrlFactory
+        Func<IServiceProvider, string> baseUrlFactory,
+        Func<IServiceProvider, string> basicAuthCredentialFactory
     )
     {
         return services.AddHttpClient<JsonApiClient>(
@@ -16,6 +17,10 @@ public static class ServiceCollectionExtensions
                 httpClient.BaseAddress = new Uri(baseUrlFactory(sp));
                 httpClient.DefaultRequestHeaders.Accept.Add(
                     new MediaTypeWithQualityHeaderValue("application/vnd.api+json")
+                );
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                    "Basic",
+                    basicAuthCredentialFactory(sp)
                 );
 
                 if (httpClient.BaseAddress.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -112,7 +112,10 @@ static void ConfigureWebApplication(WebApplicationBuilder builder)
     });
     builder.Services.AddHttpClient();
     builder.Services.AddOptions<BtmsOptions>().BindConfiguration("Btms").ValidateOptions(!generatingOpenApiFromCli);
-    builder.Services.AddJsonApiClient(sp => sp.GetRequiredService<IOptions<BtmsOptions>>().Value.BaseUrl);
+    builder.Services.AddJsonApiClient(
+        sp => sp.GetRequiredService<IOptions<BtmsOptions>>().Value.BaseUrl,
+        sp => sp.GetRequiredService<IOptions<BtmsOptions>>().Value.BasicAuthCredential
+    );
     builder.Services.AddTransient<IBtmsService, StubBtmsService>();
 
     // calls outside the platform should be done using the named 'proxy' http client.

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -27,6 +27,8 @@
     ]
   },
   "Btms": {
-    "BaseUrl": "https://btms-local/"
+    "BaseUrl": "https://btms-local/",
+    "Username": "username",
+    "Password": "password"
   }
 }

--- a/tests/Api.Tests/Configuration/BtmsOptionsTests.cs
+++ b/tests/Api.Tests/Configuration/BtmsOptionsTests.cs
@@ -1,0 +1,20 @@
+using Defra.PhaImportNotifications.Api.Configuration;
+using FluentAssertions;
+
+namespace Defra.PhaImportNotifications.Api.Tests.Configuration;
+
+public class BtmsOptionsTests
+{
+    [Fact]
+    public void BasicAuthCredential_ReturnsEncodedCredentials()
+    {
+        var btmsOptions = new BtmsOptions
+        {
+            BaseUrl = "https://test",
+            Password = "password",
+            Username = "username",
+        };
+
+        btmsOptions.BasicAuthCredential.Should().Be("dXNlcm5hbWU6cGFzc3dvcmQ=");
+    }
+}

--- a/tests/Api.Tests/JsonApi/ServiceCollectionExtensionsTests.cs
+++ b/tests/Api.Tests/JsonApi/ServiceCollectionExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Defra.PhaImportNotifications.Api.JsonApi;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,8 +13,9 @@ public class ServiceCollectionExtensionsTests
     public void AddJsonApiClient_AsExpected(string baseAddress, int expectedMajor, int expectedMinor)
     {
         var services = new ServiceCollection();
+        var authHeader = Convert.ToBase64String(Encoding.UTF8.GetBytes("username:password"));
 
-        services.AddJsonApiClient(_ => baseAddress);
+        services.AddJsonApiClient(_ => baseAddress, _ => authHeader);
 
         using var serviceProvider = services.BuildServiceProvider();
 
@@ -25,5 +27,7 @@ public class ServiceCollectionExtensionsTests
         httpClient.BaseAddress.Should().Be(new Uri(baseAddress));
         httpClient.DefaultRequestHeaders.Accept.Should().ContainSingle(x => x.MediaType == "application/vnd.api+json");
         httpClient.DefaultRequestVersion.Should().Be(new Version(expectedMajor, expectedMinor));
+        httpClient.DefaultRequestHeaders.Authorization?.Scheme.Should().Be("Basic");
+        httpClient.DefaultRequestHeaders.Authorization?.Parameter.Should().Be(authHeader);
     }
 }


### PR DESCRIPTION
BTMS currently authenticates via basic auth.
This change adds a basic auth header to all requests, configured by environment variables.