### PR TITLE
Validate path for when import notification is requested via reference number

### DIFF
--- a/Defra.PhaImportNotifications.sln.DotSettings
+++ b/Defra.PhaImportNotifications.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=btms/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=btms/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ched/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Defra.PhaImportNotifications.sln.DotSettings
+++ b/Defra.PhaImportNotifications.sln.DotSettings
@@ -1,3 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=btms/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=ched/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ched/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=cheda/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=chedd/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=chedp/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=chedpp/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.2" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />

--- a/src/Api/Endpoints/ChedReferenceNumberValidator.cs
+++ b/src/Api/Endpoints/ChedReferenceNumberValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace Defra.PhaImportNotifications.Api.Endpoints;
+
+public class ChedReferenceNumberValidator : AbstractValidator<string>
+{
+    public ChedReferenceNumberValidator()
+    {
+        RuleFor(x => x).Matches(Regexes.ChedReferenceNumber).OverridePropertyName(nameof(Regexes.ChedReferenceNumber));
+    }
+}

--- a/src/Api/Endpoints/ImportNotifications/ImportNotificationsEndpoints.cs
+++ b/src/Api/Endpoints/ImportNotifications/ImportNotificationsEndpoints.cs
@@ -1,11 +1,9 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics.CodeAnalysis;
 using Defra.PhaImportNotifications.Api.Services.Btms;
-using Defra.PhaImportNotifications.Contracts;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Defra.PhaImportNotifications.Api.Endpoints;
+namespace Defra.PhaImportNotifications.Api.Endpoints.ImportNotifications;
 
 public static class ImportNotificationsEndpoints
 {
@@ -40,8 +38,4 @@ public static class ImportNotificationsEndpoints
 
         return notification is not null ? Results.Ok(notification) : Results.NotFound();
     }
-
-    [SuppressMessage("Minor Code Smell", "S2094:Classes should not be empty")]
-    // ReSharper disable once ClassNeverInstantiated.Local
-    private sealed class ImportNotificationsResponse : ImportNotification;
 }

--- a/src/Api/Endpoints/ImportNotifications/ImportNotificationsResponse.cs
+++ b/src/Api/Endpoints/ImportNotifications/ImportNotificationsResponse.cs
@@ -1,0 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
+using Defra.PhaImportNotifications.Contracts;
+
+namespace Defra.PhaImportNotifications.Api.Endpoints.ImportNotifications;
+
+[SuppressMessage("Minor Code Smell", "S2094:Classes should not be empty")]
+// ReSharper disable once ClassNeverInstantiated.Local
+internal sealed class ImportNotificationsResponse : ImportNotification;

--- a/src/Api/Endpoints/ImportNotificationsUpdates/ImportNotificationsUpdatesEndpoints.cs
+++ b/src/Api/Endpoints/ImportNotificationsUpdates/ImportNotificationsUpdatesEndpoints.cs
@@ -2,7 +2,7 @@ using System.ComponentModel;
 using Defra.PhaImportNotifications.Api.Services.Btms;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Defra.PhaImportNotifications.Api.Endpoints;
+namespace Defra.PhaImportNotifications.Api.Endpoints.ImportNotificationsUpdates;
 
 public static class ImportNotificationsUpdatesEndpoints
 {
@@ -53,32 +53,5 @@ public static class ImportNotificationsUpdatesEndpoints
                 TotalRecords = 1,
             }
         );
-    }
-
-    // ReSharper disable once ClassNeverInstantiated.Local
-    private sealed class UpdatedImportNotificationRequest
-    {
-        [Description("Allows a specific page to be requested")]
-        [DefaultValue(1)]
-        [FromQuery(Name = "page")]
-        public int? Page { get; init; } = 1;
-
-        [Description("Allows a page size to be requested")]
-        [DefaultValue(100)]
-        [FromQuery(Name = "pageSize")]
-        public int? PageSize { get; init; } = 100;
-
-        [Description("Filter import notifications updated after this date and time. Format is ISO 8601-1:2019")]
-        [FromQuery(Name = "from")]
-        public DateTime From { get; init; }
-
-        [Description(
-            "Filter import notifications updated before this date and time. Format is ISO 8601-1:2019. Default is now ie. "
-                + "time of request. If the time period between from and to is greater than 24 hours then "
-                + "the request will be invalid."
-        )]
-        [DefaultValue(typeof(DateTime), "Time of execution")] // This doesn't add anything to the spec - do we need it?
-        [FromQuery(Name = "to")]
-        public DateTime? To { get; init; } = DateTime.Now;
     }
 }

--- a/src/Api/Endpoints/ImportNotificationsUpdates/UpdatedImportNotification.cs
+++ b/src/Api/Endpoints/ImportNotificationsUpdates/UpdatedImportNotification.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
-namespace Defra.PhaImportNotifications.Api.Endpoints;
+namespace Defra.PhaImportNotifications.Api.Endpoints.ImportNotificationsUpdates;
 
 internal sealed class UpdatedImportNotification
 {

--- a/src/Api/Endpoints/ImportNotificationsUpdates/UpdatedImportNotificationRequest.cs
+++ b/src/Api/Endpoints/ImportNotificationsUpdates/UpdatedImportNotificationRequest.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Defra.PhaImportNotifications.Api.Endpoints.ImportNotificationsUpdates;
+
+internal sealed class UpdatedImportNotificationRequest
+{
+    [Description("Allows a specific page to be requested")]
+    [DefaultValue(1)]
+    [FromQuery(Name = "page")]
+    public int? Page { get; init; } = 1;
+
+    [Description("Allows a page size to be requested")]
+    [DefaultValue(100)]
+    [FromQuery(Name = "pageSize")]
+    public int? PageSize { get; init; } = 100;
+
+    [Description("Filter import notifications updated after this date and time. Format is ISO 8601-1:2019")]
+    [FromQuery(Name = "from")]
+    public DateTime From { get; init; }
+
+    [Description(
+        "Filter import notifications updated before this date and time. Format is ISO 8601-1:2019. Default is now ie. "
+        + "time of request. If the time period between from and to is greater than 24 hours then "
+        + "the request will be invalid."
+    )]
+    [DefaultValue(typeof(DateTime), "Time of execution")] // This doesn't add anything to the spec - do we need it?
+    [FromQuery(Name = "to")]
+    public DateTime? To { get; init; } = DateTime.Now;
+}

--- a/src/Api/Endpoints/Regexes.cs
+++ b/src/Api/Endpoints/Regexes.cs
@@ -2,5 +2,5 @@ namespace Defra.PhaImportNotifications.Api.Endpoints;
 
 public static class Regexes
 {
-    public const string ChedReferenceNumber = @"CHED[A|D|P|PP]\.GB\.\d{4}\.\d{7}";
+    public const string ChedReferenceNumber = @"CHED(?:A|D|P|PP)\.GB\.\d{4}\.\d{7}";
 }

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -3,6 +3,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Defra.PhaImportNotifications.Api.Configuration;
 using Defra.PhaImportNotifications.Api.Endpoints;
+using Defra.PhaImportNotifications.Api.Endpoints.ImportNotifications;
+using Defra.PhaImportNotifications.Api.Endpoints.ImportNotificationsUpdates;
 using Defra.PhaImportNotifications.Api.Extensions;
 using Defra.PhaImportNotifications.Api.JsonApi;
 using Defra.PhaImportNotifications.Api.OpenApi;

--- a/tests/Api.IntegrationTests/Endpoints/ChedReferenceNumberValidatorTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ChedReferenceNumberValidatorTests.cs
@@ -1,0 +1,29 @@
+using Defra.PhaImportNotifications.Api.Endpoints;
+using FluentValidation.TestHelper;
+
+namespace Defra.PhaImportNotifications.Api.IntegrationTests.Endpoints;
+
+public class ChedReferenceNumberValidatorTests
+{
+    private ChedReferenceNumberValidator Subject { get; } = new();
+
+    [Fact]
+    public void Validate_WhenInvalid_ShouldError()
+    {
+        var result = Subject.TestValidate("12345");
+
+        result.ShouldHaveValidationErrorFor("ChedReferenceNumber");
+    }
+
+    [Theory]
+    [InlineData("CHEDA.GB.2024.1234567")]
+    [InlineData("CHEDD.GB.2024.1234567")]
+    [InlineData("CHEDP.GB.2024.1234567")]
+    [InlineData("CHEDPP.GB.2024.1234567")]
+    public void Validate_WhenValid_ShouldNotError(string chedReferenceNumber)
+    {
+        var result = Subject.TestValidate(chedReferenceNumber);
+
+        result.ShouldNotHaveValidationErrorFor("ChedReferenceNumber");
+    }
+}

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/ImportNotificationsEndpointsTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/ImportNotificationsEndpointsTests.cs
@@ -23,10 +23,10 @@ public class ImportNotificationsEndpointsTests(WebApplicationFactory<Program> fa
         var fixture = new Fixture();
 
         MockBtmsService
-            .GetImportNotification("mock1", Arg.Any<CancellationToken>())
+            .GetImportNotification("CHEDA.GB.2024.1234567", Arg.Any<CancellationToken>())
             .Returns(fixture.Create<ImportNotification>());
 
-        var response = await client.GetStringAsync("import-notifications/mock1");
+        var response = await client.GetStringAsync("import-notifications/CHEDA.GB.2024.1234567");
 
         // When we integrate, we will replace this with a Verify call working
         // against a builder for ImportNotification that will be generating
@@ -40,9 +40,20 @@ public class ImportNotificationsEndpointsTests(WebApplicationFactory<Program> fa
     {
         var client = CreateClient();
 
-        var response = await client.GetAsync("import-notifications/mock1");
+        var response = await client.GetAsync("import-notifications/CHEDA.GB.2024.1234567");
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_WhenInvalidChedReferenceNumber_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync("import-notifications/12345");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("ChedReferenceNumber");
     }
 
     protected override void ConfigureTestServices(IServiceCollection services)

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotificationsUpdates/ImportNotificationsUpdatesEndpointsTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotificationsUpdates/ImportNotificationsUpdatesEndpointsTests.cs
@@ -1,5 +1,6 @@
 using AutoFixture;
 using Defra.PhaImportNotifications.Api.Endpoints;
+using Defra.PhaImportNotifications.Api.Endpoints.ImportNotificationsUpdates;
 using Defra.PhaImportNotifications.Api.Services.Btms;
 using Defra.PhaImportNotifications.Contracts;
 using FluentAssertions;

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -31,7 +31,7 @@
             description: CHED Reference Number,
             required: true,
             schema: {
-              pattern: ^CHED[A|D|P|PP]\.GB\.\d{4}\.\d{7}$,
+              pattern: ^CHED(?:A|D|P|PP)\.GB\.\d{4}\.\d{7}$,
               type: string,
               description: CHED Reference Number
             },
@@ -3161,7 +3161,7 @@
           },
           uri: {
             minLength: 1,
-            pattern: ^/import-notifications/CHED[A|D|P|PP]\.GB\.\d{4}\.\d{7}$,
+            pattern: ^/import-notifications/CHED(?:A|D|P|PP)\.GB\.\d{4}\.\d{7}$,
             type: string,
             description: Relative path to import notification,
             example: /import-notifications/CHEDA.GB.2024.1020304


### PR DESCRIPTION
This PR implements path validation when requesting an import notification.

Some code files are moved to specific folders as the contents are growing.

There will be more dynamic ways in which we can control our validation logic but for now it's kept simple and explicit.