### PR TITLE
Change type generation in relation to enums so we can have nullable properties

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -92,6 +92,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder)
         c.IncludeXmlComments(typeof(ImportNotification).Assembly);
         c.DocumentFilter<TagsDocumentFilter>();
         c.SchemaFilter<DescriptionSchemaFilter>();
+        c.UseAllOfToExtendReferenceSchemas();
         c.SwaggerDoc(
             "v1",
             new OpenApiInfo

--- a/src/Contracts/AccompanyingDocument.g.cs
+++ b/src/Contracts/AccompanyingDocument.g.cs
@@ -6,7 +6,8 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class AccompanyingDocument
 {
     [JsonPropertyName("documentType")]
-    public required AccompanyingDocumentDocumentTypeEnum DocumentType { get; init; }
+    [Description("Additional document type")]
+    public AccompanyingDocumentDocumentTypeEnum? DocumentType { get; init; }
 
     [JsonPropertyName("documentReference")]
     [Description("Additional document reference")]
@@ -37,5 +38,6 @@ public class AccompanyingDocument
     public string? UploadOrganisationId { get; init; }
 
     [JsonPropertyName("externalReference")]
-    public required ExternalReference ExternalReference { get; init; }
+    [Description("External reference of accompanying document, which relates to a downstream service")]
+    public ExternalReference? ExternalReference { get; init; }
 }

--- a/src/Contracts/Address.g.cs
+++ b/src/Contracts/Address.g.cs
@@ -54,5 +54,6 @@ public class Address
     public string? Telephone { get; init; }
 
     [JsonPropertyName("internationalTelephone")]
-    public required InternationalTelephone InternationalTelephone { get; init; }
+    [Description("International phone number")]
+    public InternationalTelephone? InternationalTelephone { get; init; }
 }

--- a/src/Contracts/Applicant.g.cs
+++ b/src/Contracts/Applicant.g.cs
@@ -30,7 +30,8 @@ public class Applicant
     public string? SampleBatchNumber { get; init; }
 
     [JsonPropertyName("analysisType")]
-    public required ApplicantAnalysisTypeEnum AnalysisType { get; init; }
+    [Description("Type of analysis")]
+    public ApplicantAnalysisTypeEnum? AnalysisType { get; init; }
 
     [JsonPropertyName("numberOfSamples")]
     [Description("Number of samples analysed")]
@@ -41,10 +42,12 @@ public class Applicant
     public string? SampleType { get; init; }
 
     [JsonPropertyName("conservationOfSample")]
-    public required ApplicantConservationOfSampleEnum ConservationOfSample { get; init; }
+    [Description("Conservation of sample")]
+    public ApplicantConservationOfSampleEnum? ConservationOfSample { get; init; }
 
     [JsonPropertyName("inspector")]
-    public required Inspector Inspector { get; init; }
+    [Description("inspector")]
+    public Inspector? Inspector { get; init; }
 
     [JsonPropertyName("sampledOn")]
     [Description("DateTime")]

--- a/src/Contracts/BillingInformation.g.cs
+++ b/src/Contracts/BillingInformation.g.cs
@@ -22,5 +22,6 @@ public class BillingInformation
     public string? ContactName { get; init; }
 
     [JsonPropertyName("postalAddress")]
-    public required PostalAddress PostalAddress { get; init; }
+    [Description("Billing postal address")]
+    public PostalAddress? PostalAddress { get; init; }
 }

--- a/src/Contracts/ChedppNotAcceptableReason.g.cs
+++ b/src/Contracts/ChedppNotAcceptableReason.g.cs
@@ -6,8 +6,10 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class ChedppNotAcceptableReason
 {
     [JsonPropertyName("reason")]
-    public required ChedppNotAcceptableReasonReasonEnum Reason { get; init; }
+    [Description("reason for refusal")]
+    public ChedppNotAcceptableReasonReasonEnum? Reason { get; init; }
 
     [JsonPropertyName("commodityOrPackage")]
-    public required ChedppNotAcceptableReasonCommodityOrPackageEnum CommodityOrPackage { get; init; }
+    [Description("commodity or package")]
+    public ChedppNotAcceptableReasonCommodityOrPackageEnum? CommodityOrPackage { get; init; }
 }

--- a/src/Contracts/Commodities.g.cs
+++ b/src/Contracts/Commodities.g.cs
@@ -70,5 +70,6 @@ public class Commodities
     public string? AnimalsCertifiedAs { get; init; }
 
     [JsonPropertyName("commodityIntendedFor")]
-    public required CommoditiesCommodityIntendedForEnum CommodityIntendedFor { get; init; }
+    [Description("What the commodity is intended for")]
+    public CommoditiesCommodityIntendedForEnum? CommodityIntendedFor { get; init; }
 }

--- a/src/Contracts/CommodityComplement.g.cs
+++ b/src/Contracts/CommodityComplement.g.cs
@@ -81,7 +81,7 @@ public class CommodityComplement
     public object? AdditionalData { get; init; }
 
     [JsonPropertyName("riskAssesment")]
-    public required CommodityRiskResult RiskAssesment { get; init; }
+    public CommodityRiskResult? RiskAssesment { get; init; }
 
     [JsonPropertyName("checks")]
     public List<InspectionCheck>? Checks { get; init; }

--- a/src/Contracts/CommodityRiskResult.g.cs
+++ b/src/Contracts/CommodityRiskResult.g.cs
@@ -6,22 +6,28 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class CommodityRiskResult
 {
     [JsonPropertyName("riskDecision")]
-    public required CommodityRiskResultRiskDecisionEnum RiskDecision { get; init; }
+    [Description("CHED-A, CHED-D, CHED-P - what is the commodity complement risk decision")]
+    public CommodityRiskResultRiskDecisionEnum? RiskDecision { get; init; }
 
     [JsonPropertyName("exitRiskDecision")]
-    public required CommodityRiskResultExitRiskDecisionEnum ExitRiskDecision { get; init; }
+    [Description("Transit CHED - what is the commodity complement exit risk decision")]
+    public CommodityRiskResultExitRiskDecisionEnum? ExitRiskDecision { get; init; }
 
     [JsonPropertyName("hmiDecision")]
-    public required CommodityRiskResultHmiDecisionEnum HmiDecision { get; init; }
+    [Description("HMI decision required")]
+    public CommodityRiskResultHmiDecisionEnum? HmiDecision { get; init; }
 
     [JsonPropertyName("phsiDecision")]
-    public required CommodityRiskResultPhsiDecisionEnum PhsiDecision { get; init; }
+    [Description("PHSI decision required")]
+    public CommodityRiskResultPhsiDecisionEnum? PhsiDecision { get; init; }
 
     [JsonPropertyName("phsiClassification")]
-    public required CommodityRiskResultPhsiClassificationEnum PhsiClassification { get; init; }
+    [Description("PHSI classification")]
+    public CommodityRiskResultPhsiClassificationEnum? PhsiClassification { get; init; }
 
     [JsonPropertyName("phsi")]
-    public required Phsi Phsi { get; init; }
+    [Description("PHSI Decision Breakdown")]
+    public Phsi? Phsi { get; init; }
 
     [JsonPropertyName("uniqueId")]
     [Description("UUID used to match to the complement parameter set")]

--- a/src/Contracts/ConsignmentCheck.g.cs
+++ b/src/Contracts/ConsignmentCheck.g.cs
@@ -26,14 +26,16 @@ public class ConsignmentCheck
     public bool? IdentityCheckDone { get; init; }
 
     [JsonPropertyName("identityCheckType")]
-    public required ConsignmentCheckIdentityCheckTypeEnum IdentityCheckType { get; init; }
+    [Description("Type of identity check performed")]
+    public ConsignmentCheckIdentityCheckTypeEnum? IdentityCheckType { get; init; }
 
     [JsonPropertyName("identityCheckResult")]
     [Description("Result of identity check")]
     public string? IdentityCheckResult { get; init; }
 
     [JsonPropertyName("identityCheckNotDoneReason")]
-    public required ConsignmentCheckIdentityCheckNotDoneReasonEnum IdentityCheckNotDoneReason { get; init; }
+    [Description("What was the reason for skipping identity check")]
+    public ConsignmentCheckIdentityCheckNotDoneReasonEnum? IdentityCheckNotDoneReason { get; init; }
 
     [JsonPropertyName("physicalCheckDone")]
     [Description("Was physical check done")]
@@ -44,7 +46,8 @@ public class ConsignmentCheck
     public string? PhysicalCheckResult { get; init; }
 
     [JsonPropertyName("physicalCheckNotDoneReason")]
-    public required ConsignmentCheckPhysicalCheckNotDoneReasonEnum PhysicalCheckNotDoneReason { get; init; }
+    [Description("What was the reason for skipping physical check")]
+    public ConsignmentCheckPhysicalCheckNotDoneReasonEnum? PhysicalCheckNotDoneReason { get; init; }
 
     [JsonPropertyName("physicalCheckOtherText")]
     [Description("Other reason to not do physical check")]

--- a/src/Contracts/Control.g.cs
+++ b/src/Contracts/Control.g.cs
@@ -6,14 +6,18 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class Control
 {
     [JsonPropertyName("feedbackInformation")]
-    public required FeedbackInformation FeedbackInformation { get; init; }
+    [Description("Feedback information of Control")]
+    public FeedbackInformation? FeedbackInformation { get; init; }
 
     [JsonPropertyName("detailsOnReExport")]
-    public required DetailsOnReExport DetailsOnReExport { get; init; }
+    [Description("Details on re-export")]
+    public DetailsOnReExport? DetailsOnReExport { get; init; }
 
     [JsonPropertyName("officialInspector")]
-    public required OfficialInspector OfficialInspector { get; init; }
+    [Description("Official inspector")]
+    public OfficialInspector? OfficialInspector { get; init; }
 
     [JsonPropertyName("consignmentLeave")]
-    public required ControlConsignmentLeaveEnum ConsignmentLeave { get; init; }
+    [Description("Is the consignment leaving UK borders?")]
+    public ControlConsignmentLeaveEnum? ConsignmentLeave { get; init; }
 }

--- a/src/Contracts/ControlAuthority.g.cs
+++ b/src/Contracts/ControlAuthority.g.cs
@@ -6,7 +6,8 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class ControlAuthority
 {
     [JsonPropertyName("officialVeterinarian")]
-    public required OfficialVeterinarian OfficialVeterinarian { get; init; }
+    [Description("Official veterinarian")]
+    public OfficialVeterinarian? OfficialVeterinarian { get; init; }
 
     [JsonPropertyName("customsReferenceNo")]
     [Description("Customs reference number")]
@@ -30,5 +31,6 @@ public class ControlAuthority
     public bool? IuuCheckRequired { get; init; }
 
     [JsonPropertyName("iuuOption")]
-    public required ControlAuthorityIuuOptionEnum IuuOption { get; init; }
+    [Description("Result of Illegal, Unreported and Unregulated (IUU) check")]
+    public ControlAuthorityIuuOptionEnum? IuuOption { get; init; }
 }

--- a/src/Contracts/Decision.g.cs
+++ b/src/Contracts/Decision.g.cs
@@ -10,28 +10,36 @@ public class Decision
     public bool? ConsignmentAcceptable { get; init; }
 
     [JsonPropertyName("notAcceptableAction")]
-    public required DecisionNotAcceptableActionEnum NotAcceptableAction { get; init; }
+    [Description("Filled if consignmentAcceptable is set to false")]
+    public DecisionNotAcceptableActionEnum? NotAcceptableAction { get; init; }
 
     [JsonPropertyName("notAcceptableActionDestructionReason")]
-    public required DecisionNotAcceptableActionDestructionReasonEnum NotAcceptableActionDestructionReason { get; init; }
+    [Description("Filled if not acceptable action is set to destruction")]
+    public DecisionNotAcceptableActionDestructionReasonEnum? NotAcceptableActionDestructionReason { get; init; }
 
     [JsonPropertyName("notAcceptableActionEntryRefusalReason")]
-    public required DecisionNotAcceptableActionEntryRefusalReasonEnum NotAcceptableActionEntryRefusalReason { get; init; }
+    [Description("Filled if not acceptable action is set to entry refusal")]
+    public DecisionNotAcceptableActionEntryRefusalReasonEnum? NotAcceptableActionEntryRefusalReason { get; init; }
 
     [JsonPropertyName("notAcceptableActionQuarantineImposedReason")]
-    public required DecisionNotAcceptableActionQuarantineImposedReasonEnum NotAcceptableActionQuarantineImposedReason { get; init; }
+    [Description("Filled if not acceptable action is set to quarantine imposed")]
+    public DecisionNotAcceptableActionQuarantineImposedReasonEnum? NotAcceptableActionQuarantineImposedReason { get; init; }
 
     [JsonPropertyName("notAcceptableActionSpecialTreatmentReason")]
-    public required DecisionNotAcceptableActionSpecialTreatmentReasonEnum NotAcceptableActionSpecialTreatmentReason { get; init; }
+    [Description("Filled if not acceptable action is set to special treatment")]
+    public DecisionNotAcceptableActionSpecialTreatmentReasonEnum? NotAcceptableActionSpecialTreatmentReason { get; init; }
 
     [JsonPropertyName("notAcceptableActionIndustrialProcessingReason")]
-    public required DecisionNotAcceptableActionIndustrialProcessingReasonEnum NotAcceptableActionIndustrialProcessingReason { get; init; }
+    [Description("Filled if not acceptable action is set to industrial processing")]
+    public DecisionNotAcceptableActionIndustrialProcessingReasonEnum? NotAcceptableActionIndustrialProcessingReason { get; init; }
 
     [JsonPropertyName("notAcceptableActionReDispatchReason")]
-    public required DecisionNotAcceptableActionReDispatchReasonEnum NotAcceptableActionReDispatchReason { get; init; }
+    [Description("Filled if not acceptable action is set to re-dispatch")]
+    public DecisionNotAcceptableActionReDispatchReasonEnum? NotAcceptableActionReDispatchReason { get; init; }
 
     [JsonPropertyName("notAcceptableActionUseForOtherPurposesReason")]
-    public required DecisionNotAcceptableActionUseForOtherPurposesReasonEnum NotAcceptableActionUseForOtherPurposesReason { get; init; }
+    [Description("Filled if not acceptable action is set to use for other purposes")]
+    public DecisionNotAcceptableActionUseForOtherPurposesReasonEnum? NotAcceptableActionUseForOtherPurposesReason { get; init; }
 
     [JsonPropertyName("notAcceptableDestructionReason")]
     [Description("Filled when notAcceptableAction is equal to destruction")]
@@ -66,26 +74,32 @@ public class Decision
     public string? NotAcceptableOtherReason { get; init; }
 
     [JsonPropertyName("detailsOfControlledDestinations")]
-    public required Party DetailsOfControlledDestinations { get; init; }
+    [Description("Details of controlled destinations")]
+    public Party? DetailsOfControlledDestinations { get; init; }
 
     [JsonPropertyName("specificWarehouseNonConformingConsignment")]
-    public required DecisionSpecificWarehouseNonConformingConsignmentEnum SpecificWarehouseNonConformingConsignment { get; init; }
+    [Description("Filled if consignment is set to acceptable and decision type is Specific Warehouse")]
+    public DecisionSpecificWarehouseNonConformingConsignmentEnum? SpecificWarehouseNonConformingConsignment { get; init; }
 
     [JsonPropertyName("temporaryDeadline")]
     [Description("Deadline when consignment has to leave borders")]
     public string? TemporaryDeadline { get; init; }
 
     [JsonPropertyName("decisionEnum")]
-    public required DecisionDecisionEnum DecisionEnum { get; init; }
+    [Description("Detailed decision for consignment")]
+    public DecisionDecisionEnum? DecisionEnum { get; init; }
 
     [JsonPropertyName("freeCirculationPurpose")]
-    public required DecisionFreeCirculationPurposeEnum FreeCirculationPurpose { get; init; }
+    [Description("Decision over purpose of free circulation in country")]
+    public DecisionFreeCirculationPurposeEnum? FreeCirculationPurpose { get; init; }
 
     [JsonPropertyName("definitiveImportPurpose")]
-    public required DecisionDefinitiveImportPurposeEnum DefinitiveImportPurpose { get; init; }
+    [Description("Decision over purpose of definitive import")]
+    public DecisionDefinitiveImportPurposeEnum? DefinitiveImportPurpose { get; init; }
 
     [JsonPropertyName("ifChanneledOption")]
-    public required DecisionIfChanneledOptionEnum IfChanneledOption { get; init; }
+    [Description("Decision channeled option based on (article8, article15)")]
+    public DecisionIfChanneledOptionEnum? IfChanneledOption { get; init; }
 
     [JsonPropertyName("customWarehouseRegisteredNumber")]
     [Description("Custom warehouse registered number")]

--- a/src/Contracts/DetailsOnReExport.g.cs
+++ b/src/Contracts/DetailsOnReExport.g.cs
@@ -14,7 +14,8 @@ public class DetailsOnReExport
     public string? MeansOfTransportNo { get; init; }
 
     [JsonPropertyName("transportType")]
-    public required DetailsOnReExportTransportTypeEnum TransportType { get; init; }
+    [Description("Type of transport to be used")]
+    public DetailsOnReExportTransportTypeEnum? TransportType { get; init; }
 
     [JsonPropertyName("document")]
     [Description("Document issued for re-export")]

--- a/src/Contracts/EconomicOperator.g.cs
+++ b/src/Contracts/EconomicOperator.g.cs
@@ -10,10 +10,12 @@ public class EconomicOperator
     public string? Id { get; init; }
 
     [JsonPropertyName("type")]
-    public required EconomicOperatorTypeEnum Type { get; init; }
+    [Description("Type of organisation")]
+    public EconomicOperatorTypeEnum? Type { get; init; }
 
     [JsonPropertyName("status")]
-    public required EconomicOperatorStatusEnum Status { get; init; }
+    [Description("Status of organisation")]
+    public EconomicOperatorStatusEnum? Status { get; init; }
 
     [JsonPropertyName("companyName")]
     [Description("Name of organisation")]
@@ -24,7 +26,8 @@ public class EconomicOperator
     public string? IndividualName { get; init; }
 
     [JsonPropertyName("address")]
-    public required Address Address { get; init; }
+    [Description("Address of economic operator")]
+    public Address? Address { get; init; }
 
     [JsonPropertyName("approvalNumber")]
     [Description("Approval Number which identifies an Economic Operator unambiguously per type of organisation per country.")]

--- a/src/Contracts/ExternalReference.g.cs
+++ b/src/Contracts/ExternalReference.g.cs
@@ -6,7 +6,8 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class ExternalReference
 {
     [JsonPropertyName("system")]
-    public required ExternalReferenceSystemEnum System { get; init; }
+    [Description("Identifier of the external system to which the reference relates")]
+    public ExternalReferenceSystemEnum? System { get; init; }
 
     [JsonPropertyName("reference")]
     [Description("Reference which is added to the notification when either sent to the downstream system or received from it")]

--- a/src/Contracts/FeedbackInformation.g.cs
+++ b/src/Contracts/FeedbackInformation.g.cs
@@ -6,7 +6,8 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class FeedbackInformation
 {
     [JsonPropertyName("authorityType")]
-    public required FeedbackInformationAuthorityTypeEnum AuthorityType { get; init; }
+    [Description("Type of authority")]
+    public FeedbackInformationAuthorityTypeEnum? AuthorityType { get; init; }
 
     [JsonPropertyName("consignmentArrival")]
     [Description("Did the consignment arrive")]

--- a/src/Contracts/Identifiers.g.cs
+++ b/src/Contracts/Identifiers.g.cs
@@ -18,5 +18,6 @@ public class Identifiers
     public bool? IsPlaceOfDestinationThePermanentAddress { get; init; }
 
     [JsonPropertyName("permanentAddress")]
-    public required EconomicOperator PermanentAddress { get; init; }
+    [Description("Permanent address of the species")]
+    public EconomicOperator? PermanentAddress { get; init; }
 }

--- a/src/Contracts/ImportNotification.g.cs
+++ b/src/Contracts/ImportNotification.g.cs
@@ -30,7 +30,7 @@ public class ImportNotification
     public NotificationTdmRelationships? Relationships { get; init; }
 
     [JsonPropertyName("commoditiesSummary")]
-    public required Commodities CommoditiesSummary { get; init; }
+    public Commodities? CommoditiesSummary { get; init; }
 
     [JsonPropertyName("commodities")]
     public List<CommodityComplement>? Commodities { get; init; }
@@ -76,10 +76,12 @@ public class ImportNotification
     public DateTime? UpdatedSource { get; init; }
 
     [JsonPropertyName("lastUpdatedBy")]
-    public required UserInformation LastUpdatedBy { get; init; }
+    [Description("User entity whose update was last")]
+    public UserInformation? LastUpdatedBy { get; init; }
 
     [JsonPropertyName("importNotificationType")]
-    public required ImportNotificationTypeEnum ImportNotificationType { get; init; }
+    [Description("The Type of notification that has been submitted")]
+    public ImportNotificationTypeEnum? ImportNotificationType { get; init; }
 
     [JsonPropertyName("replaces")]
     [Description("Reference number of notification that was replaced by this one")]
@@ -90,40 +92,47 @@ public class ImportNotification
     public string? ReplacedBy { get; init; }
 
     [JsonPropertyName("status")]
-    public required ImportNotificationStatusEnum Status { get; init; }
+    [Description("Current status of the notification. When created by an importer, the notification has the status 'SUBMITTED'. Before submission of the notification it has the status 'DRAFT'. When the BIP starts validation of the notification it has the status 'IN PROGRESS' Once the BIP validates the notification, it gets the status 'VALIDATED'. 'AMEND' is set when the Part-1 user is modifying the notification. 'MODIFY' is set when Part-2 user is modifying the notification. Replaced - When the notification is replaced by another notification. Rejected - Notification moves to Rejected status when rejected by a Part-2 user. ")]
+    public ImportNotificationStatusEnum? Status { get; init; }
 
     [JsonPropertyName("splitConsignment")]
-    public required SplitConsignment SplitConsignment { get; init; }
+    [Description("Present if the consignment has been split")]
+    public SplitConsignment? SplitConsignment { get; init; }
 
     [JsonPropertyName("childNotification")]
     [Description("Is this notification a child of a split consignment?")]
     public bool? ChildNotification { get; init; }
 
     [JsonPropertyName("riskAssessment")]
-    public required RiskAssessmentResult RiskAssessment { get; init; }
+    [Description("Result of risk assessment by the risk scorer")]
+    public RiskAssessmentResult? RiskAssessment { get; init; }
 
     [JsonPropertyName("journeyRiskCategorisation")]
-    public required JourneyRiskCategorisationResult JourneyRiskCategorisation { get; init; }
+    [Description("Details of the risk categorisation level for a notification")]
+    public JourneyRiskCategorisationResult? JourneyRiskCategorisation { get; init; }
 
     [JsonPropertyName("isHighRiskEuImport")]
     [Description("Is this notification a high risk notification from the EU/EEA?")]
     public bool? IsHighRiskEuImport { get; init; }
 
     [JsonPropertyName("partOne")]
-    public required PartOne PartOne { get; init; }
+    public PartOne? PartOne { get; init; }
 
     [JsonPropertyName("decisionBy")]
-    public required UserInformation DecisionBy { get; init; }
+    [Description("Information about the user who set the decision in Part 2")]
+    public UserInformation? DecisionBy { get; init; }
 
     [JsonPropertyName("decisionDate")]
     [Description("Date when the notification was validated or rejected")]
     public string? DecisionDate { get; init; }
 
     [JsonPropertyName("partTwo")]
-    public required PartTwo PartTwo { get; init; }
+    [Description("Part of the notification which contains information filled by inspector at BIP/DPE")]
+    public PartTwo? PartTwo { get; init; }
 
     [JsonPropertyName("partThree")]
-    public required PartThree PartThree { get; init; }
+    [Description("Part of the notification which contains information filled by LVU if control of consignment is needed.")]
+    public PartThree? PartThree { get; init; }
 
     [JsonPropertyName("officialVeterinarian")]
     [Description("Official veterinarian")]

--- a/src/Contracts/InspectionCheck.g.cs
+++ b/src/Contracts/InspectionCheck.g.cs
@@ -6,10 +6,12 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class InspectionCheck
 {
     [JsonPropertyName("type")]
-    public required InspectionCheckTypeEnum Type { get; init; }
+    [Description("Type of check")]
+    public InspectionCheckTypeEnum? Type { get; init; }
 
     [JsonPropertyName("status")]
-    public required InspectionCheckStatusEnum Status { get; init; }
+    [Description("Status of the check")]
+    public InspectionCheckStatusEnum? Status { get; init; }
 
     [JsonPropertyName("reason")]
     [Description("Reason for the status if applicable")]

--- a/src/Contracts/InspectionOverride.g.cs
+++ b/src/Contracts/InspectionOverride.g.cs
@@ -14,5 +14,6 @@ public class InspectionOverride
     public DateTime? OverriddenOn { get; init; }
 
     [JsonPropertyName("overriddenBy")]
-    public required UserInformation OverriddenBy { get; init; }
+    [Description("User entity who has manually overridden the inspection")]
+    public UserInformation? OverriddenBy { get; init; }
 }

--- a/src/Contracts/JourneyRiskCategorisationResult.g.cs
+++ b/src/Contracts/JourneyRiskCategorisationResult.g.cs
@@ -6,10 +6,12 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class JourneyRiskCategorisationResult
 {
     [JsonPropertyName("riskLevel")]
-    public required JourneyRiskCategorisationResultRiskLevelEnum RiskLevel { get; init; }
+    [Description("Risk Level is defined using enum values High,Medium,Low")]
+    public JourneyRiskCategorisationResultRiskLevelEnum? RiskLevel { get; init; }
 
     [JsonPropertyName("riskLevelMethod")]
-    public required JourneyRiskCategorisationResultRiskLevelMethodEnum RiskLevelMethod { get; init; }
+    [Description("Indicator of whether the risk level was determined by the system or by the user")]
+    public JourneyRiskCategorisationResultRiskLevelMethodEnum? RiskLevelMethod { get; init; }
 
     [JsonPropertyName("riskLevelSetFor")]
     [Description("The date and time the risk level has been set for a notification")]

--- a/src/Contracts/LaboratoryTestResult.g.cs
+++ b/src/Contracts/LaboratoryTestResult.g.cs
@@ -22,7 +22,8 @@ public class LaboratoryTestResult
     public string? Results { get; init; }
 
     [JsonPropertyName("conclusion")]
-    public required LaboratoryTestResultConclusionEnum Conclusion { get; init; }
+    [Description("Conclusion of laboratory test")]
+    public LaboratoryTestResultConclusionEnum? Conclusion { get; init; }
 
     [JsonPropertyName("labTestCreatedOn")]
     [Description("Date of lab test created in IPAFFS")]

--- a/src/Contracts/LaboratoryTests.g.cs
+++ b/src/Contracts/LaboratoryTests.g.cs
@@ -10,7 +10,8 @@ public class LaboratoryTests
     public DateTime? TestedOn { get; init; }
 
     [JsonPropertyName("testReason")]
-    public required LaboratoryTestsTestReasonEnum TestReason { get; init; }
+    [Description("Reason for test")]
+    public LaboratoryTestsTestReasonEnum? TestReason { get; init; }
 
     [JsonPropertyName("singleLaboratoryTests")]
     [Description("List of details of individual tests performed or to be performed")]

--- a/src/Contracts/MeansOfTransport.g.cs
+++ b/src/Contracts/MeansOfTransport.g.cs
@@ -6,7 +6,8 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class MeansOfTransport
 {
     [JsonPropertyName("type")]
-    public required MeansOfTransportTypeEnum Type { get; init; }
+    [Description("Type of transport")]
+    public MeansOfTransportTypeEnum? Type { get; init; }
 
     [JsonPropertyName("document")]
     [Description("Document for transport")]

--- a/src/Contracts/NotificationResourceResponse.g.cs
+++ b/src/Contracts/NotificationResourceResponse.g.cs
@@ -6,5 +6,5 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class NotificationResourceResponse
 {
     [JsonPropertyName("data")]
-    public required ImportNotification Data { get; init; }
+    public ImportNotification? Data { get; init; }
 }

--- a/src/Contracts/NotificationTdmRelationships.g.cs
+++ b/src/Contracts/NotificationTdmRelationships.g.cs
@@ -6,5 +6,5 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class NotificationTdmRelationships
 {
     [JsonPropertyName("movements")]
-    public required TdmRelationshipObject Movements { get; init; }
+    public TdmRelationshipObject? Movements { get; init; }
 }

--- a/src/Contracts/OfficialInspector.g.cs
+++ b/src/Contracts/OfficialInspector.g.cs
@@ -26,7 +26,8 @@ public class OfficialInspector
     public string? Fax { get; init; }
 
     [JsonPropertyName("address")]
-    public required Address Address { get; init; }
+    [Description("Address of inspector")]
+    public Address? Address { get; init; }
 
     [JsonPropertyName("signed")]
     [Description("Date of sign")]

--- a/src/Contracts/PartOne.g.cs
+++ b/src/Contracts/PartOne.g.cs
@@ -7,10 +7,12 @@ public class PartOne
 {
     [JsonPropertyName("typeOfImp")]
     [JsonIgnore]
+    [Description("Used to indicate what type of EU Import the notification is - Live Animals, Product Of Animal Origin or High Risk Food Not Of Animal Origin")]
     public PartOneTypeOfImpEnum? TypeOfImp { get; init; }
 
     [JsonPropertyName("personResponsible")]
-    public required Party PersonResponsible { get; init; }
+    [Description("The individual who has submitted the notification")]
+    public Party? PersonResponsible { get; init; }
 
     [JsonPropertyName("customsReferenceNumber")]
     [JsonIgnore]
@@ -27,29 +29,37 @@ public class PartOne
     public bool? ConsignmentArrived { get; init; }
 
     [JsonPropertyName("consignor")]
-    public required EconomicOperator Consignor { get; init; }
+    [Description("Person or Company that sends shipment")]
+    public EconomicOperator? Consignor { get; init; }
 
     [JsonPropertyName("consignorTwo")]
     [JsonIgnore]
+    [Description("Person or Company that sends shipment")]
     public EconomicOperator? ConsignorTwo { get; init; }
 
     [JsonPropertyName("packer")]
-    public required EconomicOperator Packer { get; init; }
+    [Description("Person or Company that packs the shipment")]
+    public EconomicOperator? Packer { get; init; }
 
     [JsonPropertyName("consignee")]
-    public required EconomicOperator Consignee { get; init; }
+    [Description("Person or Company that receives shipment")]
+    public EconomicOperator? Consignee { get; init; }
 
     [JsonPropertyName("importer")]
-    public required EconomicOperator Importer { get; init; }
+    [Description("Person or Company that is importing the consignment")]
+    public EconomicOperator? Importer { get; init; }
 
     [JsonPropertyName("placeOfDestination")]
-    public required EconomicOperator PlaceOfDestination { get; init; }
+    [Description("Where the shipment is to be sent? For IMP minimum 48 hour accommodation/holding location.")]
+    public EconomicOperator? PlaceOfDestination { get; init; }
 
     [JsonPropertyName("pod")]
-    public required EconomicOperator Pod { get; init; }
+    [Description("A temporary place of destination for plants")]
+    public EconomicOperator? Pod { get; init; }
 
     [JsonPropertyName("placeOfOriginHarvest")]
     [JsonIgnore]
+    [Description("Place in which the animals or products originate")]
     public EconomicOperator? PlaceOfOriginHarvest { get; init; }
 
     [JsonPropertyName("additionalPermanentAddresses")]
@@ -80,7 +90,8 @@ public class PartOne
     public bool? IsGvmsRoute { get; init; }
 
     [JsonPropertyName("purpose")]
-    public required Purpose Purpose { get; init; }
+    [Description("Purpose of consignment details")]
+    public Purpose? Purpose { get; init; }
 
     [JsonPropertyName("pointOfEntry")]
     [Description("Either a Border-Inspection-Post or Designated-Point-Of-Entry, e.g. GBFXT1")]
@@ -91,17 +102,20 @@ public class PartOne
     public string? PointOfEntryControlPoint { get; init; }
 
     [JsonPropertyName("meansOfTransport")]
-    public required MeansOfTransport MeansOfTransport { get; init; }
+    [Description("How consignment is transported after BIP")]
+    public MeansOfTransport? MeansOfTransport { get; init; }
 
     [JsonPropertyName("transporter")]
-    public required EconomicOperator Transporter { get; init; }
+    [Description("Transporter of consignment details")]
+    public EconomicOperator? Transporter { get; init; }
 
     [JsonPropertyName("transporterDetailsRequired")]
     [Description("Are transporter details required for this consignment")]
     public bool? TransporterDetailsRequired { get; init; }
 
     [JsonPropertyName("meansOfTransportFromEntryPoint")]
-    public required MeansOfTransport MeansOfTransportFromEntryPoint { get; init; }
+    [Description("Transport to BIP")]
+    public MeansOfTransport? MeansOfTransportFromEntryPoint { get; init; }
 
     [JsonPropertyName("estimatedJourneyTimeInMinutes")]
     [Description("Estimated journey time in minutes to point of entry")]
@@ -113,14 +127,16 @@ public class PartOne
     public string? ResponsibleForTransport { get; init; }
 
     [JsonPropertyName("veterinaryInformation")]
-    public required VeterinaryInformation VeterinaryInformation { get; init; }
+    [Description("Part 1 - Holds the information related to veterinary checks and details")]
+    public VeterinaryInformation? VeterinaryInformation { get; init; }
 
     [JsonPropertyName("importerLocalReferenceNumber")]
     [Description("Reference number added by the importer")]
     public string? ImporterLocalReferenceNumber { get; init; }
 
     [JsonPropertyName("route")]
-    public required Route Route { get; init; }
+    [Description("Contains countries and transfer points that consignment is going through")]
+    public Route? Route { get; init; }
 
     [JsonPropertyName("sealsContainers")]
     [JsonIgnore]
@@ -132,7 +148,8 @@ public class PartOne
     public DateTime? SubmittedOn { get; init; }
 
     [JsonPropertyName("submittedBy")]
-    public required UserInformation SubmittedBy { get; init; }
+    [Description("Information about user who submitted notification")]
+    public UserInformation? SubmittedBy { get; init; }
 
     [JsonPropertyName("consignmentValidations")]
     [Description("Validation messages for whole notification")]
@@ -156,7 +173,8 @@ public class PartOne
     public DateTime? ExitedPortOfOn { get; init; }
 
     [JsonPropertyName("contactDetails")]
-    public required ContactDetails ContactDetails { get; init; }
+    [Description("Person to be contacted if there is an issue with the consignment")]
+    public ContactDetails? ContactDetails { get; init; }
 
     [JsonPropertyName("nominatedContacts")]
     [Description("List of nominated contacts to receive text and email notifications")]
@@ -167,7 +185,7 @@ public class PartOne
     public DateTime? OriginalEstimatedOn { get; init; }
 
     [JsonPropertyName("billingInformation")]
-    public required BillingInformation BillingInformation { get; init; }
+    public BillingInformation? BillingInformation { get; init; }
 
     [JsonPropertyName("isChargeable")]
     [Description("Indicates whether CUC applies to the notification")]
@@ -178,10 +196,11 @@ public class PartOne
     public bool? WasChargeable { get; init; }
 
     [JsonPropertyName("commonUserCharge")]
-    public required CommonUserCharge CommonUserCharge { get; init; }
+    public CommonUserCharge? CommonUserCharge { get; init; }
 
     [JsonPropertyName("provideCtcMrn")]
-    public required PartOneProvideCtcMrnEnum ProvideCtcMrn { get; init; }
+    [Description("When the NCTS MRN will be added for the Common Transit Convention (CTC)")]
+    public PartOneProvideCtcMrnEnum? ProvideCtcMrn { get; init; }
 
     [JsonPropertyName("arrivesAt")]
     [Description("DateTime")]

--- a/src/Contracts/PartThree.g.cs
+++ b/src/Contracts/PartThree.g.cs
@@ -6,10 +6,12 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class PartThree
 {
     [JsonPropertyName("controlStatus")]
-    public required PartThreeControlStatusEnum ControlStatus { get; init; }
+    [Description("Control status enum")]
+    public PartThreeControlStatusEnum? ControlStatus { get; init; }
 
     [JsonPropertyName("control")]
-    public required Control Control { get; init; }
+    [Description("Control details")]
+    public Control? Control { get; init; }
 
     [JsonPropertyName("consignmentValidations")]
     [Description("Validation messages for Part 3 - Control")]
@@ -20,8 +22,10 @@ public class PartThree
     public bool? SealCheckRequired { get; init; }
 
     [JsonPropertyName("sealCheck")]
-    public required SealCheck SealCheck { get; init; }
+    [Description("Seal check details")]
+    public SealCheck? SealCheck { get; init; }
 
     [JsonPropertyName("sealCheckOverride")]
-    public required InspectionOverride SealCheckOverride { get; init; }
+    [Description("Seal check override details")]
+    public InspectionOverride? SealCheckOverride { get; init; }
 }

--- a/src/Contracts/PartTwo.g.cs
+++ b/src/Contracts/PartTwo.g.cs
@@ -6,20 +6,24 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class PartTwo
 {
     [JsonPropertyName("decision")]
-    public required Decision Decision { get; init; }
+    [Description("Decision on the consignment")]
+    public Decision? Decision { get; init; }
 
     [JsonPropertyName("consignmentCheck")]
-    public required ConsignmentCheck ConsignmentCheck { get; init; }
+    [Description("Consignment check")]
+    public ConsignmentCheck? ConsignmentCheck { get; init; }
 
     [JsonPropertyName("impactOfTransportOnAnimals")]
-    public required ImpactOfTransportOnAnimals ImpactOfTransportOnAnimals { get; init; }
+    [Description("Checks of impact of transport on animals")]
+    public ImpactOfTransportOnAnimals? ImpactOfTransportOnAnimals { get; init; }
 
     [JsonPropertyName("laboratoryTestsRequired")]
     [Description("Are laboratory tests required")]
     public bool? LaboratoryTestsRequired { get; init; }
 
     [JsonPropertyName("laboratoryTests")]
-    public required LaboratoryTests LaboratoryTests { get; init; }
+    [Description("Laboratory tests information details")]
+    public LaboratoryTests? LaboratoryTests { get; init; }
 
     [JsonPropertyName("resealedContainersIncluded")]
     [Description("Are the containers resealed")]
@@ -35,10 +39,12 @@ public class PartTwo
     public List<SealContainer>? ResealedContainersMappings { get; init; }
 
     [JsonPropertyName("controlAuthority")]
-    public required ControlAuthority ControlAuthority { get; init; }
+    [Description("Control Authority information details")]
+    public ControlAuthority? ControlAuthority { get; init; }
 
     [JsonPropertyName("controlledDestination")]
-    public required EconomicOperator ControlledDestination { get; init; }
+    [Description("Controlled destination")]
+    public EconomicOperator? ControlledDestination { get; init; }
 
     [JsonPropertyName("bipLocalReferenceNumber")]
     [Description("Local reference number at BIP")]
@@ -77,7 +83,8 @@ public class PartTwo
     public string? InspectionRequired { get; init; }
 
     [JsonPropertyName("inspectionOverride")]
-    public required InspectionOverride InspectionOverride { get; init; }
+    [Description("Details about the manual inspection override")]
+    public InspectionOverride? InspectionOverride { get; init; }
 
     [JsonPropertyName("autoClearedOn")]
     [Description("Date of autoclearance")]

--- a/src/Contracts/Party.g.cs
+++ b/src/Contracts/Party.g.cs
@@ -50,7 +50,8 @@ public class Party
     public int? TracesId { get; init; }
 
     [JsonPropertyName("type")]
-    public required PartyTypeEnum Type { get; init; }
+    [Description("Type of party")]
+    public PartyTypeEnum? Type { get; init; }
 
     [JsonPropertyName("approvalNumber")]
     [Description("Approval number")]

--- a/src/Contracts/Purpose.g.cs
+++ b/src/Contracts/Purpose.g.cs
@@ -10,14 +10,16 @@ public class Purpose
     public bool? ConformsToEU { get; init; }
 
     [JsonPropertyName("internalMarketPurpose")]
-    public required PurposeInternalMarketPurposeEnum InternalMarketPurpose { get; init; }
+    [Description("Detailed purpose of internal market purpose group")]
+    public PurposeInternalMarketPurposeEnum? InternalMarketPurpose { get; init; }
 
     [JsonPropertyName("thirdCountryTranshipment")]
     [Description("Country that consignment is transshipped through")]
     public string? ThirdCountryTranshipment { get; init; }
 
     [JsonPropertyName("forNonConforming")]
-    public required PurposeForNonConformingEnum ForNonConforming { get; init; }
+    [Description("Detailed purpose for non conforming purpose group")]
+    public PurposeForNonConformingEnum? ForNonConforming { get; init; }
 
     [JsonPropertyName("regNumber")]
     [Description("There are 3 types of registration number based on the purpose of consignment. Customs registration number, Free zone registration number and Shipping supplier registration number.")]
@@ -44,7 +46,8 @@ public class Purpose
     public List<string>? TransitThirdCountries { get; init; }
 
     [JsonPropertyName("forImportOrAdmission")]
-    public required PurposeForImportOrAdmissionEnum ForImportOrAdmission { get; init; }
+    [Description("Specification of Import or admission purpose")]
+    public PurposeForImportOrAdmissionEnum? ForImportOrAdmission { get; init; }
 
     [JsonPropertyName("exitDate")]
     [Description("Exit date when import or admission")]
@@ -55,7 +58,8 @@ public class Purpose
     public string? FinalBip { get; init; }
 
     [JsonPropertyName("purposeGroup")]
-    public required PurposePurposeGroupEnum PurposeGroup { get; init; }
+    [Description("Purpose group of consignment (general purpose)")]
+    public PurposePurposeGroupEnum? PurposeGroup { get; init; }
 
     [JsonPropertyName("estimatedArrivesAtPortOfExit")]
     [Description("DateTime")]

--- a/src/Contracts/RelationshipDataItem.g.cs
+++ b/src/Contracts/RelationshipDataItem.g.cs
@@ -15,7 +15,7 @@ public class RelationshipDataItem
     public string? Id { get; init; }
 
     [JsonPropertyName("links")]
-    public required ResourceLink Links { get; init; }
+    public ResourceLink? Links { get; init; }
 
     [JsonPropertyName("sourceItem")]
     public int? SourceItem { get; init; }

--- a/src/Contracts/SealCheck.g.cs
+++ b/src/Contracts/SealCheck.g.cs
@@ -14,7 +14,8 @@ public class SealCheck
     public string? Reason { get; init; }
 
     [JsonPropertyName("officialInspector")]
-    public required OfficialInspector OfficialInspector { get; init; }
+    [Description("Official inspector")]
+    public OfficialInspector? OfficialInspector { get; init; }
 
     [JsonPropertyName("checkedOn")]
     [Description("date and time of seal check")]

--- a/src/Contracts/SingleLaboratoryTest.g.cs
+++ b/src/Contracts/SingleLaboratoryTest.g.cs
@@ -22,8 +22,10 @@ public class SingleLaboratoryTest
     public string? TestName { get; init; }
 
     [JsonPropertyName("applicant")]
-    public required Applicant Applicant { get; init; }
+    [Description("Laboratory tests information details and information about laboratory")]
+    public Applicant? Applicant { get; init; }
 
     [JsonPropertyName("laboratoryTestResult")]
-    public required LaboratoryTestResult LaboratoryTestResult { get; init; }
+    [Description("Information about results of test")]
+    public LaboratoryTestResult? LaboratoryTestResult { get; init; }
 }

--- a/src/Contracts/TdmRelationshipObject.g.cs
+++ b/src/Contracts/TdmRelationshipObject.g.cs
@@ -9,7 +9,7 @@ public class TdmRelationshipObject
     public bool? Matched { get; init; }
 
     [JsonPropertyName("links")]
-    public required RelationshipLinks Links { get; init; }
+    public RelationshipLinks? Links { get; init; }
 
     [JsonPropertyName("data")]
     public List<RelationshipDataItem>? Data { get; init; }

--- a/src/Contracts/VeterinaryInformation.g.cs
+++ b/src/Contracts/VeterinaryInformation.g.cs
@@ -6,7 +6,8 @@ namespace Defra.PhaImportNotifications.Contracts;
 public class VeterinaryInformation
 {
     [JsonPropertyName("establishmentsOfOriginExternalReference")]
-    public required ExternalReference EstablishmentsOfOriginExternalReference { get; init; }
+    [Description("External reference of approved establishments, which relates to a downstream service")]
+    public ExternalReference? EstablishmentsOfOriginExternalReference { get; init; }
 
     [JsonPropertyName("establishmentsOfOrigins")]
     [Description("List of establishments which were approved by UK to issue veterinary documents")]

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -1,90 +1,90 @@
 ﻿{
-  openapi: 3.0.1,
-  info: {
-    title: PHA Import Notifications,
-    description: TBC,
-    contact: {
-      name: DEFRA,
-      url: https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs,
-      email: tbc@defra.gov.uk
+  "openapi": "3.0.1",
+  "info": {
+    "title": "PHA Import Notifications",
+    "description": "TBC",
+    "contact": {
+      "name": "DEFRA",
+      "url": "https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs",
+      "email": "tbc@defra.gov.uk"
     },
-    version: v1
+    "version": "v1"
   },
-  servers: [
+  "servers": [
     {
-      url: https://localhost
+      "url": "https://localhost"
     }
   ],
-  paths: {
-    /import-notifications/{chedReferenceNumber}: {
-      get: {
-        tags: [
-          Import Notifications
+  "paths": {
+    "/import-notifications/{chedReferenceNumber}": {
+      "get": {
+        "tags": [
+          "Import Notifications"
         ],
-        summary: Get Import Notification,
-        description: Get an Import Notification by CHED Reference Number,
-        operationId: ImportNotificationsByChedReferenceNumber,
-        parameters: [
+        "summary": "Get Import Notification",
+        "description": "Get an Import Notification by CHED Reference Number",
+        "operationId": "ImportNotificationsByChedReferenceNumber",
+        "parameters": [
           {
-            name: chedReferenceNumber,
-            in: path,
-            description: CHED Reference Number,
-            required: true,
-            schema: {
-              pattern: ^CHED(?:A|D|P|PP)\.GB\.\d{4}\.\d{7}$,
-              type: string,
-              description: CHED Reference Number
+            "name": "chedReferenceNumber",
+            "in": "path",
+            "description": "CHED Reference Number",
+            "required": true,
+            "schema": {
+              "pattern": "^CHED(?:A|D|P|PP)\\.GB\\.\\d{4}\\.\\d{7}$",
+              "type": "string",
+              "description": "CHED Reference Number"
             },
-            example: CHEDA.GB.2024.1020304
+            "example": "CHEDA.GB.2024.1020304"
           }
         ],
-        responses: {
-          200: {
-            description: OK,
-            content: {
-              application/json: {
-                schema: {
-                  $ref: #/components/schemas/ImportNotificationsResponse
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportNotificationsResponse"
                 }
               }
             }
           },
-          400: {
-            description: Bad Request,
-            content: {
-              application/problem+json: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          401: {
-            description: Unauthorized,
-            content: {
-              application/problem+json: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          429: {
-            description: Too Many Requests,
-            content: {
-              application/problem+json: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          500: {
-            description: Internal Server Error,
-            content: {
-              application/problem+json: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -92,116 +92,116 @@
         }
       }
     },
-    /import-notifications-updates/{portHealthAuthority}: {
-      get: {
-        tags: [
-          Import Notifications
+    "/import-notifications-updates/{portHealthAuthority}": {
+      "get": {
+        "tags": [
+          "Import Notifications"
         ],
-        summary: Get Import Notification Updates,
-        description: Get all import notifications by port health authority that have been updated between the time period specified,
-        operationId: ImportNotificationsUpdatesByPortHealthAuthority,
-        parameters: [
+        "summary": "Get Import Notification Updates",
+        "description": "Get all import notifications by port health authority that have been updated between the time period specified",
+        "operationId": "ImportNotificationsUpdatesByPortHealthAuthority",
+        "parameters": [
           {
-            name: portHealthAuthority,
-            in: path,
-            description: The port health authority with format TBC,
-            required: true,
-            schema: {
-              type: string,
-              description: The port health authority with format TBC
+            "name": "portHealthAuthority",
+            "in": "path",
+            "description": "The port health authority with format TBC",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The port health authority with format TBC"
             }
           },
           {
-            name: page,
-            in: query,
-            description: Allows a specific page to be requested,
-            schema: {
-              type: integer,
-              description: Allows a specific page to be requested,
-              format: int32,
-              default: 1
+            "name": "page",
+            "in": "query",
+            "description": "Allows a specific page to be requested",
+            "schema": {
+              "type": "integer",
+              "description": "Allows a specific page to be requested",
+              "format": "int32",
+              "default": 1
             }
           },
           {
-            name: pageSize,
-            in: query,
-            description: Allows a page size to be requested,
-            schema: {
-              type: integer,
-              description: Allows a page size to be requested,
-              format: int32,
-              default: 100
+            "name": "pageSize",
+            "in": "query",
+            "description": "Allows a page size to be requested",
+            "schema": {
+              "type": "integer",
+              "description": "Allows a page size to be requested",
+              "format": "int32",
+              "default": 100
             }
           },
           {
-            name: from,
-            in: query,
-            description: Filter import notifications updated after this date and time. Format is ISO 8601-1:2019,
-            required: true,
-            schema: {
-              type: string,
-              description: Filter import notifications updated after this date and time. Format is ISO 8601-1:2019,
-              format: date-time
+            "name": "from",
+            "in": "query",
+            "description": "Filter import notifications updated after this date and time. Format is ISO 8601-1:2019",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Filter import notifications updated after this date and time. Format is ISO 8601-1:2019",
+              "format": "date-time"
             }
           },
           {
-            name: to,
-            in: query,
-            description: Filter import notifications updated before this date and time. Format is ISO 8601-1:2019. Default is now ie. time of request. If the time period between from and to is greater than 24 hours then the request will be invalid.,
-            schema: {
-              type: string,
-              description: Filter import notifications updated before this date and time. Format is ISO 8601-1:2019. Default is now ie. time of request. If the time period between from and to is greater than 24 hours then the request will be invalid.,
-              format: date-time
+            "name": "to",
+            "in": "query",
+            "description": "Filter import notifications updated before this date and time. Format is ISO 8601-1:2019. Default is now ie. time of request. If the time period between from and to is greater than 24 hours then the request will be invalid.",
+            "schema": {
+              "type": "string",
+              "description": "Filter import notifications updated before this date and time. Format is ISO 8601-1:2019. Default is now ie. time of request. If the time period between from and to is greater than 24 hours then the request will be invalid.",
+              "format": "date-time"
             }
           }
         ],
-        responses: {
-          200: {
-            description: OK,
-            content: {
-              application/json: {
-                schema: {
-                  $ref: #/components/schemas/UpdatedImportNotificationPagedResponse
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdatedImportNotificationPagedResponse"
                 }
               }
             }
           },
-          400: {
-            description: Bad Request,
-            content: {
-              application/problem+json: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          401: {
-            description: Unauthorized,
-            content: {
-              application/problem+json: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          429: {
-            description: Too Many Requests,
-            content: {
-              application/problem+json: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          500: {
-            description: Internal Server Error,
-            content: {
-              application/problem+json: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -210,2937 +210,3557 @@
       }
     }
   },
-  components: {
-    schemas: {
-      AccompanyingDocument: {
-        type: object,
-        properties: {
-          documentType: {
-            $ref: #/components/schemas/AccompanyingDocumentDocumentTypeEnum
+  "components": {
+    "schemas": {
+      "AccompanyingDocument": {
+        "type": "object",
+        "properties": {
+          "documentType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AccompanyingDocumentDocumentTypeEnum"
+              }
+            ],
+            "description": "Additional document type",
+            "nullable": true
           },
-          documentReference: {
-            type: string,
-            description: Additional document reference,
-            nullable: true
+          "documentReference": {
+            "type": "string",
+            "description": "Additional document reference",
+            "nullable": true
           },
-          documentIssuedOn: {
-            type: string,
-            description: Additional document issue date,
-            format: date-time,
-            nullable: true
+          "documentIssuedOn": {
+            "type": "string",
+            "description": "Additional document issue date",
+            "format": "date-time",
+            "nullable": true
           },
-          attachmentId: {
-            type: string,
-            description: The UUID used for the uploaded file in blob storage,
-            nullable: true
+          "attachmentId": {
+            "type": "string",
+            "description": "The UUID used for the uploaded file in blob storage",
+            "nullable": true
           },
-          attachmentFilename: {
-            type: string,
-            description: The original filename of the uploaded file,
-            nullable: true
+          "attachmentFilename": {
+            "type": "string",
+            "description": "The original filename of the uploaded file",
+            "nullable": true
           },
-          attachmentContentType: {
-            type: string,
-            description: The MIME type of the uploaded file,
-            nullable: true
+          "attachmentContentType": {
+            "type": "string",
+            "description": "The MIME type of the uploaded file",
+            "nullable": true
           },
-          uploadUserId: {
-            type: string,
-            description: The UUID for the user that uploaded the file,
-            nullable: true
+          "uploadUserId": {
+            "type": "string",
+            "description": "The UUID for the user that uploaded the file",
+            "nullable": true
           },
-          uploadOrganisationId: {
-            type: string,
-            description: The UUID for the organisation that the upload user is associated with,
-            nullable: true
+          "uploadOrganisationId": {
+            "type": "string",
+            "description": "The UUID for the organisation that the upload user is associated with",
+            "nullable": true
           },
-          externalReference: {
-            $ref: #/components/schemas/ExternalReference
+          "externalReference": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalReference"
+              }
+            ],
+            "description": "External reference of accompanying document, which relates to a downstream service",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      AccompanyingDocumentDocumentTypeEnum: {
-        enum: [
-          AirWaybill,
-          BillOfLading,
-          CargoManifest,
-          CatchCertificate,
-          CommercialDocument,
-          CommercialInvoice,
-          ConformityCertificate,
-          ContainerManifest,
-          CustomsDeclaration,
-          Docom,
-          HealthCertificate,
-          HeatTreatmentCertificate,
-          ImportPermit,
-          InspectionCertificate,
-          Itahc,
-          JourneyLog,
-          LaboratorySamplingResultsForAflatoxin,
-          LatestVeterinaryHealthCertificate,
-          LetterOfAuthority,
-          LicenseOrAuthorisation,
-          MycotoxinCertification,
-          OriginCertificate,
-          Other,
-          PhytosanitaryCertificate,
-          ProcessingStatement,
-          ProofOfStorage,
-          RailwayBill,
-          SeaWaybill,
-          VeterinaryHealthCertificate,
-          ListOfIngredients,
-          PackingList,
-          RoadConsignmentNote
+      "AccompanyingDocumentDocumentTypeEnum": {
+        "enum": [
+          "AirWaybill",
+          "BillOfLading",
+          "CargoManifest",
+          "CatchCertificate",
+          "CommercialDocument",
+          "CommercialInvoice",
+          "ConformityCertificate",
+          "ContainerManifest",
+          "CustomsDeclaration",
+          "Docom",
+          "HealthCertificate",
+          "HeatTreatmentCertificate",
+          "ImportPermit",
+          "InspectionCertificate",
+          "Itahc",
+          "JourneyLog",
+          "LaboratorySamplingResultsForAflatoxin",
+          "LatestVeterinaryHealthCertificate",
+          "LetterOfAuthority",
+          "LicenseOrAuthorisation",
+          "MycotoxinCertification",
+          "OriginCertificate",
+          "Other",
+          "PhytosanitaryCertificate",
+          "ProcessingStatement",
+          "ProofOfStorage",
+          "RailwayBill",
+          "SeaWaybill",
+          "VeterinaryHealthCertificate",
+          "ListOfIngredients",
+          "PackingList",
+          "RoadConsignmentNote"
         ],
-        type: string
+        "type": "string"
       },
-      Address: {
-        type: object,
-        properties: {
-          street: {
-            type: string,
-            description: Street,
-            nullable: true
+      "Address": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string",
+            "description": "Street",
+            "nullable": true
           },
-          city: {
-            type: string,
-            description: City,
-            nullable: true
+          "city": {
+            "type": "string",
+            "description": "City",
+            "nullable": true
           },
-          country: {
-            type: string,
-            description: Country,
-            nullable: true
+          "country": {
+            "type": "string",
+            "description": "Country",
+            "nullable": true
           },
-          postalCode: {
-            type: string,
-            description: Postal Code,
-            nullable: true
+          "postalCode": {
+            "type": "string",
+            "description": "Postal Code",
+            "nullable": true
           },
-          addressLine1: {
-            type: string,
-            description: 1st line of address,
-            nullable: true
+          "addressLine1": {
+            "type": "string",
+            "description": "1st line of address",
+            "nullable": true
           },
-          addressLine2: {
-            type: string,
-            description: 2nd line of address,
-            nullable: true
+          "addressLine2": {
+            "type": "string",
+            "description": "2nd line of address",
+            "nullable": true
           },
-          addressLine3: {
-            type: string,
-            description: 3rd line of address,
-            nullable: true
+          "addressLine3": {
+            "type": "string",
+            "description": "3rd line of address",
+            "nullable": true
           },
-          postalZipCode: {
-            type: string,
-            description: Post / zip code,
-            nullable: true
+          "postalZipCode": {
+            "type": "string",
+            "description": "Post / zip code",
+            "nullable": true
           },
-          countryIsoCode: {
-            type: string,
-            description: country 2-digits ISO code,
-            nullable: true
+          "countryIsoCode": {
+            "type": "string",
+            "description": "country 2-digits ISO code",
+            "nullable": true
           },
-          email: {
-            type: string,
-            description: Email address,
-            nullable: true
+          "email": {
+            "type": "string",
+            "description": "Email address",
+            "nullable": true
           },
-          ukTelephone: {
-            type: string,
-            description: UK phone number,
-            nullable: true
+          "ukTelephone": {
+            "type": "string",
+            "description": "UK phone number",
+            "nullable": true
           },
-          telephone: {
-            type: string,
-            description: Telephone number,
-            nullable: true
+          "telephone": {
+            "type": "string",
+            "description": "Telephone number",
+            "nullable": true
           },
-          internationalTelephone: {
-            $ref: #/components/schemas/InternationalTelephone
+          "internationalTelephone": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InternationalTelephone"
+              }
+            ],
+            "description": "International phone number",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      Applicant: {
-        type: object,
-        properties: {
-          laboratory: {
-            type: string,
-            description: Name of laboratory,
-            nullable: true
+      "Applicant": {
+        "type": "object",
+        "properties": {
+          "laboratory": {
+            "type": "string",
+            "description": "Name of laboratory",
+            "nullable": true
           },
-          laboratoryAddress: {
-            type: string,
-            description: Laboratory address,
-            nullable: true
+          "laboratoryAddress": {
+            "type": "string",
+            "description": "Laboratory address",
+            "nullable": true
           },
-          laboratoryIdentification: {
-            type: string,
-            description: Laboratory identification,
-            nullable: true
+          "laboratoryIdentification": {
+            "type": "string",
+            "description": "Laboratory identification",
+            "nullable": true
           },
-          laboratoryPhoneNumber: {
-            type: string,
-            description: Laboratory phone number,
-            nullable: true
+          "laboratoryPhoneNumber": {
+            "type": "string",
+            "description": "Laboratory phone number",
+            "nullable": true
           },
-          laboratoryEmail: {
-            type: string,
-            description: Laboratory email,
-            nullable: true
+          "laboratoryEmail": {
+            "type": "string",
+            "description": "Laboratory email",
+            "nullable": true
           },
-          sampleBatchNumber: {
-            type: string,
-            description: Sample batch number,
-            nullable: true
+          "sampleBatchNumber": {
+            "type": "string",
+            "description": "Sample batch number",
+            "nullable": true
           },
-          analysisType: {
-            $ref: #/components/schemas/ApplicantAnalysisTypeEnum
+          "analysisType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicantAnalysisTypeEnum"
+              }
+            ],
+            "description": "Type of analysis",
+            "nullable": true
           },
-          numberOfSamples: {
-            type: integer,
-            description: Number of samples analysed,
-            format: int32,
-            nullable: true
+          "numberOfSamples": {
+            "type": "integer",
+            "description": "Number of samples analysed",
+            "format": "int32",
+            "nullable": true
           },
-          sampleType: {
-            type: string,
-            description: Type of sample,
-            nullable: true
+          "sampleType": {
+            "type": "string",
+            "description": "Type of sample",
+            "nullable": true
           },
-          conservationOfSample: {
-            $ref: #/components/schemas/ApplicantConservationOfSampleEnum
+          "conservationOfSample": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicantConservationOfSampleEnum"
+              }
+            ],
+            "description": "Conservation of sample",
+            "nullable": true
           },
-          inspector: {
-            $ref: #/components/schemas/Inspector
+          "inspector": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Inspector"
+              }
+            ],
+            "description": "inspector",
+            "nullable": true
           },
-          sampledOn: {
-            type: string,
-            description: DateTime,
-            format: date-time,
-            nullable: true
+          "sampledOn": {
+            "type": "string",
+            "description": "DateTime",
+            "format": "date-time",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      ApplicantAnalysisTypeEnum: {
-        enum: [
-          InitialAnalysis,
-          CounterAnalysis,
-          SecondExpertAnalysis
+      "ApplicantAnalysisTypeEnum": {
+        "enum": [
+          "InitialAnalysis",
+          "CounterAnalysis",
+          "SecondExpertAnalysis"
         ],
-        type: string
+        "type": "string"
       },
-      ApplicantConservationOfSampleEnum: {
-        enum: [
-          Ambient,
-          Chilled,
-          Frozen
+      "ApplicantConservationOfSampleEnum": {
+        "enum": [
+          "Ambient",
+          "Chilled",
+          "Frozen"
         ],
-        type: string
+        "type": "string"
       },
-      ApprovedEstablishment: {
-        type: object,
-        properties: {
-          id: {
-            type: string,
-            description: ID,
-            nullable: true
+      "ApprovedEstablishment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID",
+            "nullable": true
           },
-          name: {
-            type: string,
-            description: Name of approved establishment,
-            nullable: true
+          "name": {
+            "type": "string",
+            "description": "Name of approved establishment",
+            "nullable": true
           },
-          country: {
-            type: string,
-            description: Country of approved establishment,
-            nullable: true
+          "country": {
+            "type": "string",
+            "description": "Country of approved establishment",
+            "nullable": true
           },
-          types: {
-            type: array,
-            items: {
-              type: string
+          "types": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            description: Types of approved establishment,
-            nullable: true
+            "description": "Types of approved establishment",
+            "nullable": true
           },
-          approvalNumber: {
-            type: string,
-            description: Approval number,
-            nullable: true
+          "approvalNumber": {
+            "type": "string",
+            "description": "Approval number",
+            "nullable": true
           },
-          section: {
-            type: string,
-            description: Section of approved establishment,
-            nullable: true
+          "section": {
+            "type": "string",
+            "description": "Section of approved establishment",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      BillingInformation: {
-        type: object,
-        properties: {
-          isConfirmed: {
-            type: boolean,
-            description: Indicates whether user has confirmed their billing information,
-            nullable: true
+      "BillingInformation": {
+        "type": "object",
+        "properties": {
+          "isConfirmed": {
+            "type": "boolean",
+            "description": "Indicates whether user has confirmed their billing information",
+            "nullable": true
           },
-          emailAddress: {
-            type: string,
-            description: Billing email address,
-            nullable: true
+          "emailAddress": {
+            "type": "string",
+            "description": "Billing email address",
+            "nullable": true
           },
-          phoneNumber: {
-            type: string,
-            description: Billing phone number,
-            nullable: true
+          "phoneNumber": {
+            "type": "string",
+            "description": "Billing phone number",
+            "nullable": true
           },
-          contactName: {
-            type: string,
-            description: Billing Contact Name,
-            nullable: true
+          "contactName": {
+            "type": "string",
+            "description": "Billing Contact Name",
+            "nullable": true
           },
-          postalAddress: {
-            $ref: #/components/schemas/PostalAddress
+          "postalAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PostalAddress"
+              }
+            ],
+            "description": "Billing postal address",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      CatchCertificateAttachment: {
-        type: object,
-        properties: {
-          attachmentId: {
-            type: string,
-            description: The UUID of the uploaded catch certificate file in blob storage,
-            nullable: true
+      "CatchCertificateAttachment": {
+        "type": "object",
+        "properties": {
+          "attachmentId": {
+            "type": "string",
+            "description": "The UUID of the uploaded catch certificate file in blob storage",
+            "nullable": true
           },
-          numberOfCatchCertificates: {
-            type: integer,
-            description: The total number of catch certificates on the attachment,
-            format: int32,
-            nullable: true
+          "numberOfCatchCertificates": {
+            "type": "integer",
+            "description": "The total number of catch certificates on the attachment",
+            "format": "int32",
+            "nullable": true
           },
-          catchCertificateDetails: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/CatchCertificateDetails
+          "catchCertificateDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CatchCertificateDetails"
             },
-            description: List of catch certificate details,
-            nullable: true
+            "description": "List of catch certificate details",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      CatchCertificateDetails: {
-        type: object,
-        properties: {
-          catchCertificateId: {
-            type: string,
-            description: The UUID of the catch certificate,
-            nullable: true
+      "CatchCertificateDetails": {
+        "type": "object",
+        "properties": {
+          "catchCertificateId": {
+            "type": "string",
+            "description": "The UUID of the catch certificate",
+            "nullable": true
           },
-          catchCertificateReference: {
-            type: string,
-            description: Catch certificate reference,
-            nullable: true
+          "catchCertificateReference": {
+            "type": "string",
+            "description": "Catch certificate reference",
+            "nullable": true
           },
-          issuedOn: {
-            type: string,
-            description: Catch certificate date of issue,
-            format: date-time,
-            nullable: true
+          "issuedOn": {
+            "type": "string",
+            "description": "Catch certificate date of issue",
+            "format": "date-time",
+            "nullable": true
           },
-          flagState: {
-            type: string,
-            description: Catch certificate flag state of catching vessel(s),
-            nullable: true
+          "flagState": {
+            "type": "string",
+            "description": "Catch certificate flag state of catching vessel(s)",
+            "nullable": true
           },
-          species: {
-            type: array,
-            items: {
-              type: string
+          "species": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            description: List of species imported under this catch certificate,
-            nullable: true
+            "description": "List of species imported under this catch certificate",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      ChedppNotAcceptableReason: {
-        type: object,
-        properties: {
-          reason: {
-            $ref: #/components/schemas/ChedppNotAcceptableReasonReasonEnum
+      "ChedppNotAcceptableReason": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChedppNotAcceptableReasonReasonEnum"
+              }
+            ],
+            "description": "reason for refusal",
+            "nullable": true
           },
-          commodityOrPackage: {
-            $ref: #/components/schemas/ChedppNotAcceptableReasonCommodityOrPackageEnum
+          "commodityOrPackage": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChedppNotAcceptableReasonCommodityOrPackageEnum"
+              }
+            ],
+            "description": "commodity or package",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      ChedppNotAcceptableReasonCommodityOrPackageEnum: {
-        enum: [
-          C,
-          P,
-          Cp
+      "ChedppNotAcceptableReasonCommodityOrPackageEnum": {
+        "enum": [
+          "C",
+          "P",
+          "Cp"
         ],
-        type: string
+        "type": "string"
       },
-      ChedppNotAcceptableReasonReasonEnum: {
-        enum: [
-          DocPhmdm,
-          DocPhmdii,
-          DocPa,
-          DocPic,
-          DocPill,
-          DocPed,
-          DocPmod,
-          DocPfi,
-          DocPnol,
-          DocPcne,
-          DocPadm,
-          DocPadi,
-          DocPpni,
-          DocPf,
-          DocPo,
-          DocNcevd,
-          DocNcpqefi,
-          DocNcpqebec,
-          DocNcts,
-          DocNco,
-          DocOrii,
-          DocOrsr,
-          OriOrrnu,
-          PhyOrpp,
-          PhyOrho,
-          PhyIs,
-          PhyOrsr,
-          OthCnl,
-          OthO
+      "ChedppNotAcceptableReasonReasonEnum": {
+        "enum": [
+          "DocPhmdm",
+          "DocPhmdii",
+          "DocPa",
+          "DocPic",
+          "DocPill",
+          "DocPed",
+          "DocPmod",
+          "DocPfi",
+          "DocPnol",
+          "DocPcne",
+          "DocPadm",
+          "DocPadi",
+          "DocPpni",
+          "DocPf",
+          "DocPo",
+          "DocNcevd",
+          "DocNcpqefi",
+          "DocNcpqebec",
+          "DocNcts",
+          "DocNco",
+          "DocOrii",
+          "DocOrsr",
+          "OriOrrnu",
+          "PhyOrpp",
+          "PhyOrho",
+          "PhyIs",
+          "PhyOrsr",
+          "OthCnl",
+          "OthO"
         ],
-        type: string
+        "type": "string"
       },
-      Commodities: {
-        type: object,
-        properties: {
-          gmsDeclarationAccepted: {
-            type: boolean,
-            description: Flag to record when the GMS declaration has been accepted,
-            nullable: true
+      "Commodities": {
+        "type": "object",
+        "properties": {
+          "gmsDeclarationAccepted": {
+            "type": "boolean",
+            "description": "Flag to record when the GMS declaration has been accepted",
+            "nullable": true
           },
-          consignedCountryInChargeGroup: {
-            type: boolean,
-            description: Flag to record whether the consigned country is in an ipaffs charge group,
-            nullable: true
+          "consignedCountryInChargeGroup": {
+            "type": "boolean",
+            "description": "Flag to record whether the consigned country is in an ipaffs charge group",
+            "nullable": true
           },
-          totalGrossWeight: {
-            type: number,
-            description: The total gross weight of the consignment.  It must be bigger than the total net weight of the commodities,
-            format: double,
-            nullable: true
+          "totalGrossWeight": {
+            "type": "number",
+            "description": "The total gross weight of the consignment.  It must be bigger than the total net weight of the commodities",
+            "format": "double",
+            "nullable": true
           },
-          totalNetWeight: {
-            type: number,
-            description: The total net weight of the commodities within this consignment,
-            format: double,
-            nullable: true
+          "totalNetWeight": {
+            "type": "number",
+            "description": "The total net weight of the commodities within this consignment",
+            "format": "double",
+            "nullable": true
           },
-          totalGrossVolume: {
-            type: number,
-            description: The total gross volume of the commodities within this consignment,
-            format: double,
-            nullable: true
+          "totalGrossVolume": {
+            "type": "number",
+            "description": "The total gross volume of the commodities within this consignment",
+            "format": "double",
+            "nullable": true
           },
-          totalGrossVolumeUnit: {
-            type: string,
-            description: Unit used for specifying total gross volume of this consignment (litres or metres cubed),
-            nullable: true
+          "totalGrossVolumeUnit": {
+            "type": "string",
+            "description": "Unit used for specifying total gross volume of this consignment (litres or metres cubed)",
+            "nullable": true
           },
-          numberOfPackages: {
-            type: integer,
-            description: The total number of packages within this consignment,
-            format: int32,
-            nullable: true
+          "numberOfPackages": {
+            "type": "integer",
+            "description": "The total number of packages within this consignment",
+            "format": "int32",
+            "nullable": true
           },
-          temperature: {
-            type: string,
-            description: Temperature (type) of commodity,
-            nullable: true
+          "temperature": {
+            "type": "string",
+            "description": "Temperature (type) of commodity",
+            "nullable": true
           },
-          numberOfAnimals: {
-            type: integer,
-            description: The total number of animals within this consignment,
-            format: int32,
-            nullable: true
+          "numberOfAnimals": {
+            "type": "integer",
+            "description": "The total number of animals within this consignment",
+            "format": "int32",
+            "nullable": true
           },
-          includeNonAblactedAnimals: {
-            type: boolean,
-            description: Does consignment contain ablacted animals,
-            nullable: true
+          "includeNonAblactedAnimals": {
+            "type": "boolean",
+            "description": "Does consignment contain ablacted animals",
+            "nullable": true
           },
-          countryOfOrigin: {
-            type: string,
-            description: Consignments country of origin,
-            nullable: true
+          "countryOfOrigin": {
+            "type": "string",
+            "description": "Consignments country of origin",
+            "nullable": true
           },
-          countryOfOriginIsPodCountry: {
-            type: boolean,
-            description: Flag to record whether country of origin is a temporary PoD country,
-            nullable: true
+          "countryOfOriginIsPodCountry": {
+            "type": "boolean",
+            "description": "Flag to record whether country of origin is a temporary PoD country",
+            "nullable": true
           },
-          isLowRiskArticle72Country: {
-            type: boolean,
-            description: Flag to record whether country of origin is a low risk article 72 country,
-            nullable: true
+          "isLowRiskArticle72Country": {
+            "type": "boolean",
+            "description": "Flag to record whether country of origin is a low risk article 72 country",
+            "nullable": true
           },
-          regionOfOrigin: {
-            type: string,
-            description: Region of country,
-            nullable: true
+          "regionOfOrigin": {
+            "type": "string",
+            "description": "Region of country",
+            "nullable": true
           },
-          consignedCountry: {
-            type: string,
-            description: Country from where commodity was sent,
-            nullable: true
+          "consignedCountry": {
+            "type": "string",
+            "description": "Country from where commodity was sent",
+            "nullable": true
           },
-          animalsCertifiedAs: {
-            type: string,
-            description: Certification of animals (Breeding, slaughter etc.),
-            nullable: true
+          "animalsCertifiedAs": {
+            "type": "string",
+            "description": "Certification of animals (Breeding, slaughter etc.)",
+            "nullable": true
           },
-          commodityIntendedFor: {
-            $ref: #/components/schemas/CommoditiesCommodityIntendedForEnum
+          "commodityIntendedFor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommoditiesCommodityIntendedForEnum"
+              }
+            ],
+            "description": "What the commodity is intended for",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      CommoditiesCommodityIntendedForEnum: {
-        enum: [
-          Human,
-          Feedingstuff,
-          Further,
-          Other
+      "CommoditiesCommodityIntendedForEnum": {
+        "enum": [
+          "Human",
+          "Feedingstuff",
+          "Further",
+          "Other"
         ],
-        type: string
+        "type": "string"
       },
-      CommodityComplement: {
-        type: object,
-        properties: {
-          uniqueComplementId: {
-            type: string,
-            description: UUID used to match commodityComplement to its complementParameter set. CHEDPP only,
-            nullable: true
+      "CommodityComplement": {
+        "type": "object",
+        "properties": {
+          "uniqueComplementId": {
+            "type": "string",
+            "description": "UUID used to match commodityComplement to its complementParameter set. CHEDPP only",
+            "nullable": true
           },
-          commodityDescription: {
-            type: string,
-            description: Description of the commodity,
-            nullable: true
+          "commodityDescription": {
+            "type": "string",
+            "description": "Description of the commodity",
+            "nullable": true
           },
-          commodityId: {
-            type: string,
-            description: The unique commodity ID,
-            nullable: true
+          "commodityId": {
+            "type": "string",
+            "description": "The unique commodity ID",
+            "nullable": true
           },
-          complementId: {
-            type: integer,
-            description: Identifier of complement chosen from speciesFamily,speciesClass and speciesType'. This is also used to link to the complementParameterSet,
-            format: int32,
-            nullable: true
+          "complementId": {
+            "type": "integer",
+            "description": "Identifier of complement chosen from speciesFamily,speciesClass and speciesType'. This is also used to link to the complementParameterSet",
+            "format": "int32",
+            "nullable": true
           },
-          complementName: {
-            type: string,
-            description: Represents the lowest granularity - either type, class, family or species name - for the commodity selected.  This is also used to drive behaviour for EU Import journeys,
-            nullable: true
+          "complementName": {
+            "type": "string",
+            "description": "Represents the lowest granularity - either type, class, family or species name - for the commodity selected.  This is also used to drive behaviour for EU Import journeys",
+            "nullable": true
           },
-          eppoCode: {
-            type: string,
-            description: EPPO Code related to plant commodities and wood packaging,
-            nullable: true
+          "eppoCode": {
+            "type": "string",
+            "description": "EPPO Code related to plant commodities and wood packaging",
+            "nullable": true
           },
-          isWoodPackaging: {
-            type: boolean,
-            description: (Deprecated in IMTA-11832) Is this commodity wood packaging?,
-            nullable: true
+          "isWoodPackaging": {
+            "type": "boolean",
+            "description": "(Deprecated in IMTA-11832) Is this commodity wood packaging?",
+            "nullable": true
           },
-          speciesId: {
-            type: string,
-            description: The species ID of the commodity that is imported. Not every commodity has a species ID. This is also used to link to the complementParameterSet. The species ID can change over time,
-            nullable: true
+          "speciesId": {
+            "type": "string",
+            "description": "The species ID of the commodity that is imported. Not every commodity has a species ID. This is also used to link to the complementParameterSet. The species ID can change over time",
+            "nullable": true
           },
-          speciesName: {
-            type: string,
-            description: Species name,
-            nullable: true
+          "speciesName": {
+            "type": "string",
+            "description": "Species name",
+            "nullable": true
           },
-          speciesNomination: {
-            type: string,
-            description: Species nomination,
-            nullable: true
+          "speciesNomination": {
+            "type": "string",
+            "description": "Species nomination",
+            "nullable": true
           },
-          speciesTypeName: {
-            type: string,
-            description: Species type name,
-            nullable: true
+          "speciesTypeName": {
+            "type": "string",
+            "description": "Species type name",
+            "nullable": true
           },
-          speciesType: {
-            type: string,
-            description: Species type identifier of commodity,
-            nullable: true
+          "speciesType": {
+            "type": "string",
+            "description": "Species type identifier of commodity",
+            "nullable": true
           },
-          speciesClassName: {
-            type: string,
-            description: Species class name,
-            nullable: true
+          "speciesClassName": {
+            "type": "string",
+            "description": "Species class name",
+            "nullable": true
           },
-          speciesClass: {
-            type: string,
-            description: Species class identifier of commodity,
-            nullable: true
+          "speciesClass": {
+            "type": "string",
+            "description": "Species class identifier of commodity",
+            "nullable": true
           },
-          speciesFamilyName: {
-            type: string,
-            description: Species family name of commodity,
-            nullable: true
+          "speciesFamilyName": {
+            "type": "string",
+            "description": "Species family name of commodity",
+            "nullable": true
           },
-          speciesFamily: {
-            type: string,
-            description: Species family identifier of commodity,
-            nullable: true
+          "speciesFamily": {
+            "type": "string",
+            "description": "Species family identifier of commodity",
+            "nullable": true
           },
-          speciesCommonName: {
-            type: string,
-            description: Species common name of commodity for IMP notification simple commodity selection,
-            nullable: true
+          "speciesCommonName": {
+            "type": "string",
+            "description": "Species common name of commodity for IMP notification simple commodity selection",
+            "nullable": true
           },
-          isCdsMatched: {
-            type: boolean,
-            description: Has commodity been matched with corresponding CDS declaration,
-            nullable: true
+          "isCdsMatched": {
+            "type": "boolean",
+            "description": "Has commodity been matched with corresponding CDS declaration",
+            "nullable": true
           },
-          additionalData: {
-            nullable: true
+          "additionalData": {
+            "nullable": true
           },
-          riskAssesment: {
-            $ref: #/components/schemas/CommodityRiskResult
+          "riskAssesment": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResult"
+              }
+            ],
+            "nullable": true
           },
-          checks: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/InspectionCheck
+          "checks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InspectionCheck"
             },
-            nullable: true
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      CommodityRiskResult: {
-        type: object,
-        properties: {
-          riskDecision: {
-            $ref: #/components/schemas/CommodityRiskResultRiskDecisionEnum
+      "CommodityRiskResult": {
+        "type": "object",
+        "properties": {
+          "riskDecision": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResultRiskDecisionEnum"
+              }
+            ],
+            "description": "CHED-A, CHED-D, CHED-P - what is the commodity complement risk decision",
+            "nullable": true
           },
-          exitRiskDecision: {
-            $ref: #/components/schemas/CommodityRiskResultExitRiskDecisionEnum
+          "exitRiskDecision": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResultExitRiskDecisionEnum"
+              }
+            ],
+            "description": "Transit CHED - what is the commodity complement exit risk decision",
+            "nullable": true
           },
-          hmiDecision: {
-            $ref: #/components/schemas/CommodityRiskResultHmiDecisionEnum
+          "hmiDecision": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResultHmiDecisionEnum"
+              }
+            ],
+            "description": "HMI decision required",
+            "nullable": true
           },
-          phsiDecision: {
-            $ref: #/components/schemas/CommodityRiskResultPhsiDecisionEnum
+          "phsiDecision": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResultPhsiDecisionEnum"
+              }
+            ],
+            "description": "PHSI decision required",
+            "nullable": true
           },
-          phsiClassification: {
-            $ref: #/components/schemas/CommodityRiskResultPhsiClassificationEnum
+          "phsiClassification": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResultPhsiClassificationEnum"
+              }
+            ],
+            "description": "PHSI classification",
+            "nullable": true
           },
-          phsi: {
-            $ref: #/components/schemas/Phsi
+          "phsi": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Phsi"
+              }
+            ],
+            "description": "PHSI Decision Breakdown",
+            "nullable": true
           },
-          uniqueId: {
-            type: string,
-            description: UUID used to match to the complement parameter set,
-            nullable: true
+          "uniqueId": {
+            "type": "string",
+            "description": "UUID used to match to the complement parameter set",
+            "nullable": true
           },
-          eppoCode: {
-            type: string,
-            description: EPPO Code for the species,
-            nullable: true
+          "eppoCode": {
+            "type": "string",
+            "description": "EPPO Code for the species",
+            "nullable": true
           },
-          variety: {
-            type: string,
-            description: Name or ID of the variety,
-            nullable: true
+          "variety": {
+            "type": "string",
+            "description": "Name or ID of the variety",
+            "nullable": true
           },
-          propagation: {
-            type: string,
-            description: Whether the propagation is considered a Plant, Bulb, Seed or None,
-            nullable: true
+          "propagation": {
+            "type": "string",
+            "description": "Whether the propagation is considered a Plant, Bulb, Seed or None",
+            "nullable": true
           },
-          phsiRuleType: {
-            type: string,
-            description: Rule type for PHSI checks,
-            nullable: true
+          "phsiRuleType": {
+            "type": "string",
+            "description": "Rule type for PHSI checks",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      CommodityRiskResultExitRiskDecisionEnum: {
-        enum: [
-          Required,
-          Notrequired,
-          Inconclusive
+      "CommodityRiskResultExitRiskDecisionEnum": {
+        "enum": [
+          "Required",
+          "Notrequired",
+          "Inconclusive"
         ],
-        type: string
+        "type": "string"
       },
-      CommodityRiskResultHmiDecisionEnum: {
-        enum: [
-          Required,
-          Notrequired
+      "CommodityRiskResultHmiDecisionEnum": {
+        "enum": [
+          "Required",
+          "Notrequired"
         ],
-        type: string
+        "type": "string"
       },
-      CommodityRiskResultPhsiClassificationEnum: {
-        enum: [
-          Mandatory,
-          Reduced,
-          Controlled
+      "CommodityRiskResultPhsiClassificationEnum": {
+        "enum": [
+          "Mandatory",
+          "Reduced",
+          "Controlled"
         ],
-        type: string
+        "type": "string"
       },
-      CommodityRiskResultPhsiDecisionEnum: {
-        enum: [
-          Required,
-          Notrequired
+      "CommodityRiskResultPhsiDecisionEnum": {
+        "enum": [
+          "Required",
+          "Notrequired"
         ],
-        type: string
+        "type": "string"
       },
-      CommodityRiskResultRiskDecisionEnum: {
-        enum: [
-          Required,
-          Notrequired,
-          Inconclusive,
-          ReenforcedCheck
+      "CommodityRiskResultRiskDecisionEnum": {
+        "enum": [
+          "Required",
+          "Notrequired",
+          "Inconclusive",
+          "ReenforcedCheck"
         ],
-        type: string
+        "type": "string"
       },
-      CommonUserCharge: {
-        type: object,
-        properties: {
-          wasSentToTradeCharge: {
-            type: boolean,
-            description: Indicates whether the last applicable change was successfully send over the interface to Trade Charge,
-            nullable: true
+      "CommonUserCharge": {
+        "type": "object",
+        "properties": {
+          "wasSentToTradeCharge": {
+            "type": "boolean",
+            "description": "Indicates whether the last applicable change was successfully send over the interface to Trade Charge",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      ConsignmentCheck: {
-        type: object,
-        properties: {
-          euStandard: {
-            type: string,
-            description: Does it conform EU standards,
-            nullable: true
+      "ConsignmentCheck": {
+        "type": "object",
+        "properties": {
+          "euStandard": {
+            "type": "string",
+            "description": "Does it conform EU standards",
+            "nullable": true
           },
-          additionalGuarantees: {
-            type: string,
-            description: Result of additional guarantees,
-            nullable: true
+          "additionalGuarantees": {
+            "type": "string",
+            "description": "Result of additional guarantees",
+            "nullable": true
           },
-          documentCheckResult: {
-            type: string,
-            description: Result of document check,
-            nullable: true
+          "documentCheckResult": {
+            "type": "string",
+            "description": "Result of document check",
+            "nullable": true
           },
-          nationalRequirements: {
-            type: string,
-            description: Result of national requirements check,
-            nullable: true
+          "nationalRequirements": {
+            "type": "string",
+            "description": "Result of national requirements check",
+            "nullable": true
           },
-          identityCheckDone: {
-            type: boolean,
-            description: Was identity check done,
-            nullable: true
+          "identityCheckDone": {
+            "type": "boolean",
+            "description": "Was identity check done",
+            "nullable": true
           },
-          identityCheckType: {
-            $ref: #/components/schemas/ConsignmentCheckIdentityCheckTypeEnum
+          "identityCheckType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConsignmentCheckIdentityCheckTypeEnum"
+              }
+            ],
+            "description": "Type of identity check performed",
+            "nullable": true
           },
-          identityCheckResult: {
-            type: string,
-            description: Result of identity check,
-            nullable: true
+          "identityCheckResult": {
+            "type": "string",
+            "description": "Result of identity check",
+            "nullable": true
           },
-          identityCheckNotDoneReason: {
-            $ref: #/components/schemas/ConsignmentCheckIdentityCheckNotDoneReasonEnum
+          "identityCheckNotDoneReason": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConsignmentCheckIdentityCheckNotDoneReasonEnum"
+              }
+            ],
+            "description": "What was the reason for skipping identity check",
+            "nullable": true
           },
-          physicalCheckDone: {
-            type: boolean,
-            description: Was physical check done,
-            nullable: true
+          "physicalCheckDone": {
+            "type": "boolean",
+            "description": "Was physical check done",
+            "nullable": true
           },
-          physicalCheckResult: {
-            type: string,
-            description: Result of physical check,
-            nullable: true
+          "physicalCheckResult": {
+            "type": "string",
+            "description": "Result of physical check",
+            "nullable": true
           },
-          physicalCheckNotDoneReason: {
-            $ref: #/components/schemas/ConsignmentCheckPhysicalCheckNotDoneReasonEnum
+          "physicalCheckNotDoneReason": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConsignmentCheckPhysicalCheckNotDoneReasonEnum"
+              }
+            ],
+            "description": "What was the reason for skipping physical check",
+            "nullable": true
           },
-          physicalCheckOtherText: {
-            type: string,
-            description: Other reason to not do physical check,
-            nullable: true
+          "physicalCheckOtherText": {
+            "type": "string",
+            "description": "Other reason to not do physical check",
+            "nullable": true
           },
-          welfareCheck: {
-            type: string,
-            description: Welfare check,
-            nullable: true
+          "welfareCheck": {
+            "type": "string",
+            "description": "Welfare check",
+            "nullable": true
           },
-          numberOfAnimalsChecked: {
-            type: integer,
-            description: Number of animals checked,
-            format: int32,
-            nullable: true
+          "numberOfAnimalsChecked": {
+            "type": "integer",
+            "description": "Number of animals checked",
+            "format": "int32",
+            "nullable": true
           },
-          laboratoryCheckDone: {
-            type: boolean,
-            description: Were laboratory tests done,
-            nullable: true
+          "laboratoryCheckDone": {
+            "type": "boolean",
+            "description": "Were laboratory tests done",
+            "nullable": true
           },
-          laboratoryCheckResult: {
-            type: string,
-            description: Result of laboratory tests,
-            nullable: true
+          "laboratoryCheckResult": {
+            "type": "string",
+            "description": "Result of laboratory tests",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      ConsignmentCheckIdentityCheckNotDoneReasonEnum: {
-        enum: [
-          ReducedChecksRegime,
-          NotRequired
+      "ConsignmentCheckIdentityCheckNotDoneReasonEnum": {
+        "enum": [
+          "ReducedChecksRegime",
+          "NotRequired"
         ],
-        type: string
+        "type": "string"
       },
-      ConsignmentCheckIdentityCheckTypeEnum: {
-        enum: [
-          SealCheck,
-          FullIdentityCheck,
-          NotDone
+      "ConsignmentCheckIdentityCheckTypeEnum": {
+        "enum": [
+          "SealCheck",
+          "FullIdentityCheck",
+          "NotDone"
         ],
-        type: string
+        "type": "string"
       },
-      ConsignmentCheckPhysicalCheckNotDoneReasonEnum: {
-        enum: [
-          ReducedChecksRegime,
-          Other
+      "ConsignmentCheckPhysicalCheckNotDoneReasonEnum": {
+        "enum": [
+          "ReducedChecksRegime",
+          "Other"
         ],
-        type: string
+        "type": "string"
       },
-      ContactDetails: {
-        type: object,
-        properties: {
-          name: {
-            type: string,
-            description: Name of designated contact,
-            nullable: true
+      "ContactDetails": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of designated contact",
+            "nullable": true
           },
-          telephone: {
-            type: string,
-            description: Telephone number of designated contact,
-            nullable: true
+          "telephone": {
+            "type": "string",
+            "description": "Telephone number of designated contact",
+            "nullable": true
           },
-          email: {
-            type: string,
-            description: Email address of designated contact,
-            nullable: true
+          "email": {
+            "type": "string",
+            "description": "Email address of designated contact",
+            "nullable": true
           },
-          agent: {
-            type: string,
-            description: Name of agent representing designated contact,
-            nullable: true
+          "agent": {
+            "type": "string",
+            "description": "Name of agent representing designated contact",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      Control: {
-        type: object,
-        properties: {
-          feedbackInformation: {
-            $ref: #/components/schemas/FeedbackInformation
+      "Control": {
+        "type": "object",
+        "properties": {
+          "feedbackInformation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FeedbackInformation"
+              }
+            ],
+            "description": "Feedback information of Control",
+            "nullable": true
           },
-          detailsOnReExport: {
-            $ref: #/components/schemas/DetailsOnReExport
+          "detailsOnReExport": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DetailsOnReExport"
+              }
+            ],
+            "description": "Details on re-export",
+            "nullable": true
           },
-          officialInspector: {
-            $ref: #/components/schemas/OfficialInspector
+          "officialInspector": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OfficialInspector"
+              }
+            ],
+            "description": "Official inspector",
+            "nullable": true
           },
-          consignmentLeave: {
-            $ref: #/components/schemas/ControlConsignmentLeaveEnum
+          "consignmentLeave": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ControlConsignmentLeaveEnum"
+              }
+            ],
+            "description": "Is the consignment leaving UK borders?",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      ControlAuthority: {
-        type: object,
-        properties: {
-          officialVeterinarian: {
-            $ref: #/components/schemas/OfficialVeterinarian
+      "ControlAuthority": {
+        "type": "object",
+        "properties": {
+          "officialVeterinarian": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OfficialVeterinarian"
+              }
+            ],
+            "description": "Official veterinarian",
+            "nullable": true
           },
-          customsReferenceNo: {
-            type: string,
-            description: Customs reference number,
-            nullable: true
+          "customsReferenceNo": {
+            "type": "string",
+            "description": "Customs reference number",
+            "nullable": true
           },
-          containerResealed: {
-            type: boolean,
-            description: Were containers resealed?,
-            nullable: true
+          "containerResealed": {
+            "type": "boolean",
+            "description": "Were containers resealed?",
+            "nullable": true
           },
-          newSealNumber: {
-            type: string,
-            description: When the containers are resealed they need new seal numbers,
-            nullable: true
+          "newSealNumber": {
+            "type": "string",
+            "description": "When the containers are resealed they need new seal numbers",
+            "nullable": true
           },
-          iuuCheckRequired: {
-            type: boolean,
-            description: Was Illegal, Unreported and Unregulated (IUU) check required,
-            nullable: true
+          "iuuCheckRequired": {
+            "type": "boolean",
+            "description": "Was Illegal, Unreported and Unregulated (IUU) check required",
+            "nullable": true
           },
-          iuuOption: {
-            $ref: #/components/schemas/ControlAuthorityIuuOptionEnum
+          "iuuOption": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ControlAuthorityIuuOptionEnum"
+              }
+            ],
+            "description": "Result of Illegal, Unreported and Unregulated (IUU) check",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      ControlAuthorityIuuOptionEnum: {
-        enum: [
-          Iuuok,
-          Iuuna,
-          IUUNotCompliant
+      "ControlAuthorityIuuOptionEnum": {
+        "enum": [
+          "Iuuok",
+          "Iuuna",
+          "IUUNotCompliant"
         ],
-        type: string
+        "type": "string"
       },
-      ControlConsignmentLeaveEnum: {
-        enum: [
-          Yes,
-          No,
-          ItHasBeenDestroyed
+      "ControlConsignmentLeaveEnum": {
+        "enum": [
+          "Yes",
+          "No",
+          "ItHasBeenDestroyed"
         ],
-        type: string
+        "type": "string"
       },
-      Decision: {
-        type: object,
-        properties: {
-          consignmentAcceptable: {
-            type: boolean,
-            description: Is consignment acceptable or not,
-            nullable: true
+      "Decision": {
+        "type": "object",
+        "properties": {
+          "consignmentAcceptable": {
+            "type": "boolean",
+            "description": "Is consignment acceptable or not",
+            "nullable": true
           },
-          notAcceptableAction: {
-            $ref: #/components/schemas/DecisionNotAcceptableActionEnum
+          "notAcceptableAction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionEnum"
+              }
+            ],
+            "description": "Filled if consignmentAcceptable is set to false",
+            "nullable": true
           },
-          notAcceptableActionDestructionReason: {
-            $ref: #/components/schemas/DecisionNotAcceptableActionDestructionReasonEnum
+          "notAcceptableActionDestructionReason": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionDestructionReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to destruction",
+            "nullable": true
           },
-          notAcceptableActionEntryRefusalReason: {
-            $ref: #/components/schemas/DecisionNotAcceptableActionEntryRefusalReasonEnum
+          "notAcceptableActionEntryRefusalReason": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionEntryRefusalReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to entry refusal",
+            "nullable": true
           },
-          notAcceptableActionQuarantineImposedReason: {
-            $ref: #/components/schemas/DecisionNotAcceptableActionQuarantineImposedReasonEnum
+          "notAcceptableActionQuarantineImposedReason": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionQuarantineImposedReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to quarantine imposed",
+            "nullable": true
           },
-          notAcceptableActionSpecialTreatmentReason: {
-            $ref: #/components/schemas/DecisionNotAcceptableActionSpecialTreatmentReasonEnum
+          "notAcceptableActionSpecialTreatmentReason": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionSpecialTreatmentReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to special treatment",
+            "nullable": true
           },
-          notAcceptableActionIndustrialProcessingReason: {
-            $ref: #/components/schemas/DecisionNotAcceptableActionIndustrialProcessingReasonEnum
+          "notAcceptableActionIndustrialProcessingReason": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionIndustrialProcessingReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to industrial processing",
+            "nullable": true
           },
-          notAcceptableActionReDispatchReason: {
-            $ref: #/components/schemas/DecisionNotAcceptableActionReDispatchReasonEnum
+          "notAcceptableActionReDispatchReason": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionReDispatchReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to re-dispatch",
+            "nullable": true
           },
-          notAcceptableActionUseForOtherPurposesReason: {
-            $ref: #/components/schemas/DecisionNotAcceptableActionUseForOtherPurposesReasonEnum
+          "notAcceptableActionUseForOtherPurposesReason": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionUseForOtherPurposesReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to use for other purposes",
+            "nullable": true
           },
-          notAcceptableDestructionReason: {
-            type: string,
-            description: Filled when notAcceptableAction is equal to destruction,
-            nullable: true
+          "notAcceptableDestructionReason": {
+            "type": "string",
+            "description": "Filled when notAcceptableAction is equal to destruction",
+            "nullable": true
           },
-          notAcceptableActionOtherReason: {
-            type: string,
-            description: Filled when notAcceptableAction is equal to other,
-            nullable: true
+          "notAcceptableActionOtherReason": {
+            "type": "string",
+            "description": "Filled when notAcceptableAction is equal to other",
+            "nullable": true
           },
-          notAcceptableActionByDate: {
-            type: string,
-            description: Filled when consignmentAcceptable is set to false,
-            nullable: true
+          "notAcceptableActionByDate": {
+            "type": "string",
+            "description": "Filled when consignmentAcceptable is set to false",
+            "nullable": true
           },
-          chedppNotAcceptableReasons: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/ChedppNotAcceptableReason
+          "chedppNotAcceptableReasons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChedppNotAcceptableReason"
             },
-            description: List of details for individual chedpp not acceptable reasons,
-            nullable: true
+            "description": "List of details for individual chedpp not acceptable reasons",
+            "nullable": true
           },
-          notAcceptableReasons: {
-            type: array,
-            items: {
-              type: string
+          "notAcceptableReasons": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            description: If the consignment was not accepted what was the reason,
-            nullable: true
+            "description": "If the consignment was not accepted what was the reason",
+            "nullable": true
           },
-          notAcceptableCountry: {
-            type: string,
-            description: 2 digits ISO code of country (not acceptable country can be empty),
-            nullable: true
+          "notAcceptableCountry": {
+            "type": "string",
+            "description": "2 digits ISO code of country (not acceptable country can be empty)",
+            "nullable": true
           },
-          notAcceptableEstablishment: {
-            type: string,
-            description: Filled if consignmentAcceptable is set to false,
-            nullable: true
+          "notAcceptableEstablishment": {
+            "type": "string",
+            "description": "Filled if consignmentAcceptable is set to false",
+            "nullable": true
           },
-          notAcceptableOtherReason: {
-            type: string,
-            description: Filled if consignmentAcceptable is set to false,
-            nullable: true
+          "notAcceptableOtherReason": {
+            "type": "string",
+            "description": "Filled if consignmentAcceptable is set to false",
+            "nullable": true
           },
-          detailsOfControlledDestinations: {
-            $ref: #/components/schemas/Party
+          "detailsOfControlledDestinations": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Party"
+              }
+            ],
+            "description": "Details of controlled destinations",
+            "nullable": true
           },
-          specificWarehouseNonConformingConsignment: {
-            $ref: #/components/schemas/DecisionSpecificWarehouseNonConformingConsignmentEnum
+          "specificWarehouseNonConformingConsignment": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionSpecificWarehouseNonConformingConsignmentEnum"
+              }
+            ],
+            "description": "Filled if consignment is set to acceptable and decision type is Specific Warehouse",
+            "nullable": true
           },
-          temporaryDeadline: {
-            type: string,
-            description: Deadline when consignment has to leave borders,
-            nullable: true
+          "temporaryDeadline": {
+            "type": "string",
+            "description": "Deadline when consignment has to leave borders",
+            "nullable": true
           },
-          decisionEnum: {
-            $ref: #/components/schemas/DecisionDecisionEnum
+          "decisionEnum": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionDecisionEnum"
+              }
+            ],
+            "description": "Detailed decision for consignment",
+            "nullable": true
           },
-          freeCirculationPurpose: {
-            $ref: #/components/schemas/DecisionFreeCirculationPurposeEnum
+          "freeCirculationPurpose": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionFreeCirculationPurposeEnum"
+              }
+            ],
+            "description": "Decision over purpose of free circulation in country",
+            "nullable": true
           },
-          definitiveImportPurpose: {
-            $ref: #/components/schemas/DecisionDefinitiveImportPurposeEnum
+          "definitiveImportPurpose": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionDefinitiveImportPurposeEnum"
+              }
+            ],
+            "description": "Decision over purpose of definitive import",
+            "nullable": true
           },
-          ifChanneledOption: {
-            $ref: #/components/schemas/DecisionIfChanneledOptionEnum
+          "ifChanneledOption": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionIfChanneledOptionEnum"
+              }
+            ],
+            "description": "Decision channeled option based on (article8, article15)",
+            "nullable": true
           },
-          customWarehouseRegisteredNumber: {
-            type: string,
-            description: Custom warehouse registered number,
-            nullable: true
+          "customWarehouseRegisteredNumber": {
+            "type": "string",
+            "description": "Custom warehouse registered number",
+            "nullable": true
           },
-          freeWarehouseRegisteredNumber: {
-            type: string,
-            description: Free warehouse registered number,
-            nullable: true
+          "freeWarehouseRegisteredNumber": {
+            "type": "string",
+            "description": "Free warehouse registered number",
+            "nullable": true
           },
-          shipName: {
-            type: string,
-            description: Ship name,
-            nullable: true
+          "shipName": {
+            "type": "string",
+            "description": "Ship name",
+            "nullable": true
           },
-          shipPortOfExit: {
-            type: string,
-            description: Port of exit,
-            nullable: true
+          "shipPortOfExit": {
+            "type": "string",
+            "description": "Port of exit",
+            "nullable": true
           },
-          shipSupplierRegisteredNumber: {
-            type: string,
-            description: Ship supplier registered number,
-            nullable: true
+          "shipSupplierRegisteredNumber": {
+            "type": "string",
+            "description": "Ship supplier registered number",
+            "nullable": true
           },
-          transhipmentBip: {
-            type: string,
-            description: Transhipment BIP,
-            nullable: true
+          "transhipmentBip": {
+            "type": "string",
+            "description": "Transhipment BIP",
+            "nullable": true
           },
-          transhipmentThirdCountry: {
-            type: string,
-            description: Transhipment third country,
-            nullable: true
+          "transhipmentThirdCountry": {
+            "type": "string",
+            "description": "Transhipment third country",
+            "nullable": true
           },
-          transitExitBip: {
-            type: string,
-            description: Transit exit BIP,
-            nullable: true
+          "transitExitBip": {
+            "type": "string",
+            "description": "Transit exit BIP",
+            "nullable": true
           },
-          transitThirdCountry: {
-            type: string,
-            description: Transit third country,
-            nullable: true
+          "transitThirdCountry": {
+            "type": "string",
+            "description": "Transit third country",
+            "nullable": true
           },
-          transitDestinationThirdCountry: {
-            type: string,
-            description: Transit destination third country,
-            nullable: true
+          "transitDestinationThirdCountry": {
+            "type": "string",
+            "description": "Transit destination third country",
+            "nullable": true
           },
-          temporaryExitBip: {
-            type: string,
-            description: Temporary exit BIP,
-            nullable: true
+          "temporaryExitBip": {
+            "type": "string",
+            "description": "Temporary exit BIP",
+            "nullable": true
           },
-          horseReentry: {
-            type: string,
-            description: Horse re-entry,
-            nullable: true
+          "horseReentry": {
+            "type": "string",
+            "description": "Horse re-entry",
+            "nullable": true
           },
-          transhipmentEuOrThirdCountry: {
-            type: string,
-            description: Is it transshipped to EU or third country (values EU / country name),
-            nullable: true
+          "transhipmentEuOrThirdCountry": {
+            "type": "string",
+            "description": "Is it transshipped to EU or third country (values EU / country name)",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      DecisionDecisionEnum: {
-        enum: [
-          NonAcceptable,
-          AcceptableForInternalMarket,
-          AcceptableIfChanneled,
-          AcceptableForTranshipment,
-          AcceptableForTransit,
-          AcceptableForTemporaryImport,
-          AcceptableForSpecificWarehouse,
-          AcceptableForPrivateImport,
-          AcceptableForTransfer,
-          HorseReEntry
+      "DecisionDecisionEnum": {
+        "enum": [
+          "NonAcceptable",
+          "AcceptableForInternalMarket",
+          "AcceptableIfChanneled",
+          "AcceptableForTranshipment",
+          "AcceptableForTransit",
+          "AcceptableForTemporaryImport",
+          "AcceptableForSpecificWarehouse",
+          "AcceptableForPrivateImport",
+          "AcceptableForTransfer",
+          "HorseReEntry"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionDefinitiveImportPurposeEnum: {
-        enum: [
-          Slaughter,
-          Approvedbodies,
-          Quarantine
+      "DecisionDefinitiveImportPurposeEnum": {
+        "enum": [
+          "Slaughter",
+          "Approvedbodies",
+          "Quarantine"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionFreeCirculationPurposeEnum: {
-        enum: [
-          AnimalFeedingStuff,
-          HumanConsumption,
-          PharmaceuticalUse,
-          TechnicalUse,
-          FurtherProcess,
-          Other
+      "DecisionFreeCirculationPurposeEnum": {
+        "enum": [
+          "AnimalFeedingStuff",
+          "HumanConsumption",
+          "PharmaceuticalUse",
+          "TechnicalUse",
+          "FurtherProcess",
+          "Other"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionIfChanneledOptionEnum: {
-        enum: [
-          Article8,
-          Article15
+      "DecisionIfChanneledOptionEnum": {
+        "enum": [
+          "Article8",
+          "Article15"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionNotAcceptableActionDestructionReasonEnum: {
-        enum: [
-          ContaminatedProducts,
-          InterceptedPart,
-          PackagingMaterial,
-          Other
+      "DecisionNotAcceptableActionDestructionReasonEnum": {
+        "enum": [
+          "ContaminatedProducts",
+          "InterceptedPart",
+          "PackagingMaterial",
+          "Other"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionNotAcceptableActionEntryRefusalReasonEnum: {
-        enum: [
-          ContaminatedProducts,
-          InterceptedPart,
-          PackagingMaterial,
-          MeansOfTransport,
-          Other
+      "DecisionNotAcceptableActionEntryRefusalReasonEnum": {
+        "enum": [
+          "ContaminatedProducts",
+          "InterceptedPart",
+          "PackagingMaterial",
+          "MeansOfTransport",
+          "Other"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionNotAcceptableActionEnum: {
-        enum: [
-          Slaughter,
-          Reexport,
-          Euthanasia,
-          Redispatching,
-          Destruction,
-          Transformation,
-          Other,
-          EntryRefusal,
-          QuarantineImposed,
-          SpecialTreatment,
-          IndustrialProcessing,
-          ReDispatch,
-          UseForOtherPurposes
+      "DecisionNotAcceptableActionEnum": {
+        "enum": [
+          "Slaughter",
+          "Reexport",
+          "Euthanasia",
+          "Redispatching",
+          "Destruction",
+          "Transformation",
+          "Other",
+          "EntryRefusal",
+          "QuarantineImposed",
+          "SpecialTreatment",
+          "IndustrialProcessing",
+          "ReDispatch",
+          "UseForOtherPurposes"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionNotAcceptableActionIndustrialProcessingReasonEnum: {
-        enum: [
-          ContaminatedProducts,
-          InterceptedPart,
-          PackagingMaterial,
-          Other
+      "DecisionNotAcceptableActionIndustrialProcessingReasonEnum": {
+        "enum": [
+          "ContaminatedProducts",
+          "InterceptedPart",
+          "PackagingMaterial",
+          "Other"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionNotAcceptableActionQuarantineImposedReasonEnum: {
-        enum: [
-          ContaminatedProducts,
-          InterceptedPart,
-          PackagingMaterial,
-          Other
+      "DecisionNotAcceptableActionQuarantineImposedReasonEnum": {
+        "enum": [
+          "ContaminatedProducts",
+          "InterceptedPart",
+          "PackagingMaterial",
+          "Other"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionNotAcceptableActionReDispatchReasonEnum: {
-        enum: [
-          ContaminatedProducts,
-          InterceptedPart,
-          PackagingMaterial,
-          MeansOfTransport,
-          Other
+      "DecisionNotAcceptableActionReDispatchReasonEnum": {
+        "enum": [
+          "ContaminatedProducts",
+          "InterceptedPart",
+          "PackagingMaterial",
+          "MeansOfTransport",
+          "Other"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionNotAcceptableActionSpecialTreatmentReasonEnum: {
-        enum: [
-          ContaminatedProducts,
-          InterceptedPart,
-          PackagingMaterial,
-          Other
+      "DecisionNotAcceptableActionSpecialTreatmentReasonEnum": {
+        "enum": [
+          "ContaminatedProducts",
+          "InterceptedPart",
+          "PackagingMaterial",
+          "Other"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionNotAcceptableActionUseForOtherPurposesReasonEnum: {
-        enum: [
-          ContaminatedProducts,
-          InterceptedPart,
-          PackagingMaterial,
-          MeansOfTransport,
-          Other
+      "DecisionNotAcceptableActionUseForOtherPurposesReasonEnum": {
+        "enum": [
+          "ContaminatedProducts",
+          "InterceptedPart",
+          "PackagingMaterial",
+          "MeansOfTransport",
+          "Other"
         ],
-        type: string
+        "type": "string"
       },
-      DecisionSpecificWarehouseNonConformingConsignmentEnum: {
-        enum: [
-          CustomWarehouse,
-          FreeZoneOrFreeWarehouse,
-          ShipSupplier,
-          Ship
+      "DecisionSpecificWarehouseNonConformingConsignmentEnum": {
+        "enum": [
+          "CustomWarehouse",
+          "FreeZoneOrFreeWarehouse",
+          "ShipSupplier",
+          "Ship"
         ],
-        type: string
+        "type": "string"
       },
-      DetailsOnReExport: {
-        type: object,
-        properties: {
-          date: {
-            type: string,
-            description: Date of re-export,
-            format: date-time,
-            nullable: true
+      "DetailsOnReExport": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "description": "Date of re-export",
+            "format": "date-time",
+            "nullable": true
           },
-          meansOfTransportNo: {
-            type: string,
-            description: Number of vehicle,
-            nullable: true
+          "meansOfTransportNo": {
+            "type": "string",
+            "description": "Number of vehicle",
+            "nullable": true
           },
-          transportType: {
-            $ref: #/components/schemas/DetailsOnReExportTransportTypeEnum
+          "transportType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DetailsOnReExportTransportTypeEnum"
+              }
+            ],
+            "description": "Type of transport to be used",
+            "nullable": true
           },
-          document: {
-            type: string,
-            description: Document issued for re-export,
-            nullable: true
+          "document": {
+            "type": "string",
+            "description": "Document issued for re-export",
+            "nullable": true
           },
-          countryOfReDispatching: {
-            type: string,
-            description: Two letter ISO code for country of re-dispatching,
-            nullable: true
+          "countryOfReDispatching": {
+            "type": "string",
+            "description": "Two letter ISO code for country of re-dispatching",
+            "nullable": true
           },
-          exitBip: {
-            type: string,
-            description: Exit BIP (where consignment will leave the country),
-            nullable: true
+          "exitBip": {
+            "type": "string",
+            "description": "Exit BIP (where consignment will leave the country)",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      DetailsOnReExportTransportTypeEnum: {
-        enum: [
-          Rail,
-          Plane,
-          Ship,
-          Road,
-          Other,
-          CShipRoad,
-          CShipRail
+      "DetailsOnReExportTransportTypeEnum": {
+        "enum": [
+          "Rail",
+          "Plane",
+          "Ship",
+          "Road",
+          "Other",
+          "CShipRoad",
+          "CShipRail"
         ],
-        type: string
+        "type": "string"
       },
-      EconomicOperator: {
-        type: object,
-        properties: {
-          id: {
-            type: string,
-            description: The unique identifier of this organisation,
-            nullable: true
+      "EconomicOperator": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of this organisation",
+            "nullable": true
           },
-          type: {
-            $ref: #/components/schemas/EconomicOperatorTypeEnum
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperatorTypeEnum"
+              }
+            ],
+            "description": "Type of organisation",
+            "nullable": true
           },
-          status: {
-            $ref: #/components/schemas/EconomicOperatorStatusEnum
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperatorStatusEnum"
+              }
+            ],
+            "description": "Status of organisation",
+            "nullable": true
           },
-          companyName: {
-            type: string,
-            description: Name of organisation,
-            nullable: true
+          "companyName": {
+            "type": "string",
+            "description": "Name of organisation",
+            "nullable": true
           },
-          individualName: {
-            type: string,
-            description: Individual name,
-            nullable: true
+          "individualName": {
+            "type": "string",
+            "description": "Individual name",
+            "nullable": true
           },
-          address: {
-            $ref: #/components/schemas/Address
+          "address": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Address"
+              }
+            ],
+            "description": "Address of economic operator",
+            "nullable": true
           },
-          approvalNumber: {
-            type: string,
-            description: Approval Number which identifies an Economic Operator unambiguously per type of organisation per country.,
-            nullable: true
+          "approvalNumber": {
+            "type": "string",
+            "description": "Approval Number which identifies an Economic Operator unambiguously per type of organisation per country.",
+            "nullable": true
           },
-          otherIdentifier: {
-            type: string,
-            description: Optional Business General Number, often named Aggregation Code, which identifies an Economic Operator.,
-            nullable: true
+          "otherIdentifier": {
+            "type": "string",
+            "description": "Optional Business General Number, often named Aggregation Code, which identifies an Economic Operator.",
+            "nullable": true
           },
-          tracesId: {
-            type: integer,
-            description: Traces Id of the economic operator generated by IPAFFS,
-            format: int32,
-            nullable: true
+          "tracesId": {
+            "type": "integer",
+            "description": "Traces Id of the economic operator generated by IPAFFS",
+            "format": "int32",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      EconomicOperatorStatusEnum: {
-        enum: [
-          Approved,
-          Nonapproved,
-          Suspended
+      "EconomicOperatorStatusEnum": {
+        "enum": [
+          "Approved",
+          "Nonapproved",
+          "Suspended"
         ],
-        type: string
+        "type": "string"
       },
-      EconomicOperatorTypeEnum: {
-        enum: [
-          Consignee,
-          Destination,
-          Exporter,
-          Importer,
-          Charity,
-          CommercialTransporter,
-          CommercialTransporterUserAdded,
-          PrivateTransporter,
-          TemporaryAddress,
-          PremisesOfOrigin,
-          OrganisationBranchAddress,
-          Packer,
-          Pod
+      "EconomicOperatorTypeEnum": {
+        "enum": [
+          "Consignee",
+          "Destination",
+          "Exporter",
+          "Importer",
+          "Charity",
+          "CommercialTransporter",
+          "CommercialTransporterUserAdded",
+          "PrivateTransporter",
+          "TemporaryAddress",
+          "PremisesOfOrigin",
+          "OrganisationBranchAddress",
+          "Packer",
+          "Pod"
         ],
-        type: string
+        "type": "string"
       },
-      ExternalReference: {
-        type: object,
-        properties: {
-          system: {
-            $ref: #/components/schemas/ExternalReferenceSystemEnum
+      "ExternalReference": {
+        "type": "object",
+        "properties": {
+          "system": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalReferenceSystemEnum"
+              }
+            ],
+            "description": "Identifier of the external system to which the reference relates",
+            "nullable": true
           },
-          reference: {
-            type: string,
-            description: Reference which is added to the notification when either sent to the downstream system or received from it,
-            nullable: true
+          "reference": {
+            "type": "string",
+            "description": "Reference which is added to the notification when either sent to the downstream system or received from it",
+            "nullable": true
           },
-          exactMatch: {
-            type: boolean,
-            description: Details whether there's an exact match between the external source and IPAFFS data,
-            nullable: true
+          "exactMatch": {
+            "type": "boolean",
+            "description": "Details whether there's an exact match between the external source and IPAFFS data",
+            "nullable": true
           },
-          verifiedByImporter: {
-            type: boolean,
-            description: Details whether an importer has verified the data from an external source,
-            nullable: true
+          "verifiedByImporter": {
+            "type": "boolean",
+            "description": "Details whether an importer has verified the data from an external source",
+            "nullable": true
           },
-          verifiedByInspector: {
-            type: boolean,
-            description: Details whether an inspector has verified the data from an external source,
-            nullable: true
+          "verifiedByInspector": {
+            "type": "boolean",
+            "description": "Details whether an inspector has verified the data from an external source",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      ExternalReferenceSystemEnum: {
-        enum: [
-          Ecert,
-          Ephyto,
-          Enotification,
-          Ncts
+      "ExternalReferenceSystemEnum": {
+        "enum": [
+          "Ecert",
+          "Ephyto",
+          "Enotification",
+          "Ncts"
         ],
-        type: string
+        "type": "string"
       },
-      FeedbackInformation: {
-        type: object,
-        properties: {
-          authorityType: {
-            $ref: #/components/schemas/FeedbackInformationAuthorityTypeEnum
+      "FeedbackInformation": {
+        "type": "object",
+        "properties": {
+          "authorityType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FeedbackInformationAuthorityTypeEnum"
+              }
+            ],
+            "description": "Type of authority",
+            "nullable": true
           },
-          consignmentArrival: {
-            type: boolean,
-            description: Did the consignment arrive,
-            nullable: true
+          "consignmentArrival": {
+            "type": "boolean",
+            "description": "Did the consignment arrive",
+            "nullable": true
           },
-          consignmentConformity: {
-            type: boolean,
-            description: Does the consignment conform,
-            nullable: true
+          "consignmentConformity": {
+            "type": "boolean",
+            "description": "Does the consignment conform",
+            "nullable": true
           },
-          consignmentNoArrivalReason: {
-            type: string,
-            description: Reason for consignment not arriving at the entry point,
-            nullable: true
+          "consignmentNoArrivalReason": {
+            "type": "string",
+            "description": "Reason for consignment not arriving at the entry point",
+            "nullable": true
           },
-          destructionDate: {
-            type: string,
-            description: Date of consignment destruction,
-            nullable: true
+          "destructionDate": {
+            "type": "string",
+            "description": "Date of consignment destruction",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      FeedbackInformationAuthorityTypeEnum: {
-        enum: [
-          Exitbip,
-          Finalbip,
-          Localvetunit,
-          Inspunit
+      "FeedbackInformationAuthorityTypeEnum": {
+        "enum": [
+          "Exitbip",
+          "Finalbip",
+          "Localvetunit",
+          "Inspunit"
         ],
-        type: string
+        "type": "string"
       },
-      ImpactOfTransportOnAnimals: {
-        type: object,
-        properties: {
-          numberOfDeadAnimals: {
-            type: integer,
-            description: Number of dead animals specified by units,
-            format: int32,
-            nullable: true
+      "ImpactOfTransportOnAnimals": {
+        "type": "object",
+        "properties": {
+          "numberOfDeadAnimals": {
+            "type": "integer",
+            "description": "Number of dead animals specified by units",
+            "format": "int32",
+            "nullable": true
           },
-          numberOfDeadAnimalsUnit: {
-            type: string,
-            description: Unit used for specifying number of dead animals (percent or units),
-            nullable: true
+          "numberOfDeadAnimalsUnit": {
+            "type": "string",
+            "description": "Unit used for specifying number of dead animals (percent or units)",
+            "nullable": true
           },
-          numberOfUnfitAnimals: {
-            type: integer,
-            description: Number of unfit animals,
-            format: int32,
-            nullable: true
+          "numberOfUnfitAnimals": {
+            "type": "integer",
+            "description": "Number of unfit animals",
+            "format": "int32",
+            "nullable": true
           },
-          numberOfUnfitAnimalsUnit: {
-            type: string,
-            description: Unit used for specifying number of unfit animals (percent or units),
-            nullable: true
+          "numberOfUnfitAnimalsUnit": {
+            "type": "string",
+            "description": "Unit used for specifying number of unfit animals (percent or units)",
+            "nullable": true
           },
-          numberOfBirthOrAbortion: {
-            type: integer,
-            description: Number of births or abortions (unit),
-            format: int32,
-            nullable: true
+          "numberOfBirthOrAbortion": {
+            "type": "integer",
+            "description": "Number of births or abortions (unit)",
+            "format": "int32",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      ImportNotificationStatusEnum: {
-        enum: [
-          Draft,
-          Submitted,
-          Validated,
-          Rejected,
-          InProgress,
-          Amend,
-          Modify,
-          Replaced,
-          Cancelled,
-          Deleted,
-          PartiallyRejected,
-          SplitConsignment
+      "ImportNotificationStatusEnum": {
+        "enum": [
+          "Draft",
+          "Submitted",
+          "Validated",
+          "Rejected",
+          "InProgress",
+          "Amend",
+          "Modify",
+          "Replaced",
+          "Cancelled",
+          "Deleted",
+          "PartiallyRejected",
+          "SplitConsignment"
         ],
-        type: string
+        "type": "string"
       },
-      ImportNotificationTypeEnum: {
-        enum: [
-          Cveda,
-          Cvedp,
-          Chedpp,
-          Ced,
-          Imp
+      "ImportNotificationTypeEnum": {
+        "enum": [
+          "Cveda",
+          "Cvedp",
+          "Chedpp",
+          "Ced",
+          "Imp"
         ],
-        type: string
+        "type": "string"
       },
-      ImportNotificationsResponse: {
-        required: [
-          created,
-          updated
+      "ImportNotificationsResponse": {
+        "required": [
+          "created",
+          "updated"
         ],
-        type: object,
-        properties: {
-          createdSource: {
-            type: string,
-            description: Date when the notification was created in IPAFFS,
-            format: date-time,
-            nullable: true
+        "type": "object",
+        "properties": {
+          "createdSource": {
+            "type": "string",
+            "description": "Date when the notification was created in IPAFFS",
+            "format": "date-time",
+            "nullable": true
           },
-          created: {
-            type: string,
-            description: Date when the notification was created,
-            format: date-time
+          "created": {
+            "type": "string",
+            "description": "Date when the notification was created",
+            "format": "date-time"
           },
-          updated: {
-            type: string,
-            description: Date when the notification was last updated,
-            format: date-time
+          "updated": {
+            "type": "string",
+            "description": "Date when the notification was last updated",
+            "format": "date-time"
           },
-          commoditiesSummary: {
-            $ref: #/components/schemas/Commodities
+          "commoditiesSummary": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Commodities"
+              }
+            ],
+            "nullable": true
           },
-          commodities: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/CommodityComplement
+          "commodities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommodityComplement"
             },
-            nullable: true
+            "nullable": true
           },
-          ipaffsId: {
-            type: integer,
-            description: The IPAFFS ID number for this notification.,
-            format: int32,
-            nullable: true
+          "ipaffsId": {
+            "type": "integer",
+            "description": "The IPAFFS ID number for this notification.",
+            "format": "int32",
+            "nullable": true
           },
-          etag: {
-            type: string,
-            description: The etag for this notification.,
-            nullable: true
+          "etag": {
+            "type": "string",
+            "description": "The etag for this notification.",
+            "nullable": true
           },
-          externalReferences: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/ExternalReference
+          "externalReferences": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExternalReference"
             },
-            description: List of external references, which relate to downstream services,
-            nullable: true
+            "description": "List of external references, which relate to downstream services",
+            "nullable": true
           },
-          referenceNumber: {
-            type: string,
-            description: Reference number of the notification,
-            nullable: true
+          "referenceNumber": {
+            "type": "string",
+            "description": "Reference number of the notification",
+            "nullable": true
           },
-          version: {
-            type: integer,
-            description: Current version of the notification,
-            format: int32,
-            nullable: true
+          "version": {
+            "type": "integer",
+            "description": "Current version of the notification",
+            "format": "int32",
+            "nullable": true
           },
-          updatedSource: {
-            type: string,
-            description: Date when the notification was last updated in IPAFFS,
-            format: date-time,
-            nullable: true
+          "updatedSource": {
+            "type": "string",
+            "description": "Date when the notification was last updated in IPAFFS",
+            "format": "date-time",
+            "nullable": true
           },
-          lastUpdatedBy: {
-            $ref: #/components/schemas/UserInformation
+          "lastUpdatedBy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserInformation"
+              }
+            ],
+            "description": "User entity whose update was last",
+            "nullable": true
           },
-          importNotificationType: {
-            $ref: #/components/schemas/ImportNotificationTypeEnum
+          "importNotificationType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImportNotificationTypeEnum"
+              }
+            ],
+            "description": "The Type of notification that has been submitted",
+            "nullable": true
           },
-          replaces: {
-            type: string,
-            description: Reference number of notification that was replaced by this one,
-            nullable: true
+          "replaces": {
+            "type": "string",
+            "description": "Reference number of notification that was replaced by this one",
+            "nullable": true
           },
-          replacedBy: {
-            type: string,
-            description: Reference number of notification that replaced this one,
-            nullable: true
+          "replacedBy": {
+            "type": "string",
+            "description": "Reference number of notification that replaced this one",
+            "nullable": true
           },
-          status: {
-            $ref: #/components/schemas/ImportNotificationStatusEnum
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImportNotificationStatusEnum"
+              }
+            ],
+            "description": "Current status of the notification. When created by an importer, the notification has the status 'SUBMITTED'. Before submission of the notification it has the status 'DRAFT'. When the BIP starts validation of the notification it has the status 'IN PROGRESS' Once the BIP validates the notification, it gets the status 'VALIDATED'. 'AMEND' is set when the Part-1 user is modifying the notification. 'MODIFY' is set when Part-2 user is modifying the notification. Replaced - When the notification is replaced by another notification. Rejected - Notification moves to Rejected status when rejected by a Part-2 user. ",
+            "nullable": true
           },
-          splitConsignment: {
-            $ref: #/components/schemas/SplitConsignment
+          "splitConsignment": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SplitConsignment"
+              }
+            ],
+            "description": "Present if the consignment has been split",
+            "nullable": true
           },
-          childNotification: {
-            type: boolean,
-            description: Is this notification a child of a split consignment?,
-            nullable: true
+          "childNotification": {
+            "type": "boolean",
+            "description": "Is this notification a child of a split consignment?",
+            "nullable": true
           },
-          riskAssessment: {
-            $ref: #/components/schemas/RiskAssessmentResult
+          "riskAssessment": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskAssessmentResult"
+              }
+            ],
+            "description": "Result of risk assessment by the risk scorer",
+            "nullable": true
           },
-          journeyRiskCategorisation: {
-            $ref: #/components/schemas/JourneyRiskCategorisationResult
+          "journeyRiskCategorisation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JourneyRiskCategorisationResult"
+              }
+            ],
+            "description": "Details of the risk categorisation level for a notification",
+            "nullable": true
           },
-          isHighRiskEuImport: {
-            type: boolean,
-            description: Is this notification a high risk notification from the EU/EEA?,
-            nullable: true
+          "isHighRiskEuImport": {
+            "type": "boolean",
+            "description": "Is this notification a high risk notification from the EU/EEA?",
+            "nullable": true
           },
-          partOne: {
-            $ref: #/components/schemas/PartOne
+          "partOne": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartOne"
+              }
+            ],
+            "nullable": true
           },
-          decisionBy: {
-            $ref: #/components/schemas/UserInformation
+          "decisionBy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserInformation"
+              }
+            ],
+            "description": "Information about the user who set the decision in Part 2",
+            "nullable": true
           },
-          decisionDate: {
-            type: string,
-            description: Date when the notification was validated or rejected,
-            nullable: true
+          "decisionDate": {
+            "type": "string",
+            "description": "Date when the notification was validated or rejected",
+            "nullable": true
           },
-          partTwo: {
-            $ref: #/components/schemas/PartTwo
+          "partTwo": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartTwo"
+              }
+            ],
+            "description": "Part of the notification which contains information filled by inspector at BIP/DPE",
+            "nullable": true
           },
-          partThree: {
-            $ref: #/components/schemas/PartThree
+          "partThree": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartThree"
+              }
+            ],
+            "description": "Part of the notification which contains information filled by LVU if control of consignment is needed.",
+            "nullable": true
           },
-          officialVeterinarian: {
-            type: string,
-            description: Official veterinarian,
-            nullable: true
+          "officialVeterinarian": {
+            "type": "string",
+            "description": "Official veterinarian",
+            "nullable": true
           },
-          consignmentValidations: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/ValidationMessageCode
+          "consignmentValidations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationMessageCode"
             },
-            description: Validation messages for whole notification,
-            nullable: true
+            "description": "Validation messages for whole notification",
+            "nullable": true
           },
-          agencyOrganisationId: {
-            type: string,
-            description: Organisation id which the agent user belongs to, stored against each notification which has been raised on behalf of another organisation,
-            nullable: true
+          "agencyOrganisationId": {
+            "type": "string",
+            "description": "Organisation id which the agent user belongs to, stored against each notification which has been raised on behalf of another organisation",
+            "nullable": true
           },
-          riskDecisionLockedOn: {
-            type: string,
-            description: Date and Time when risk decision was locked,
-            format: date-time,
-            nullable: true
+          "riskDecisionLockedOn": {
+            "type": "string",
+            "description": "Date and Time when risk decision was locked",
+            "format": "date-time",
+            "nullable": true
           },
-          isRiskDecisionLocked: {
-            type: boolean,
-            description: is the risk decision locked?,
-            nullable: true
+          "isRiskDecisionLocked": {
+            "type": "boolean",
+            "description": "is the risk decision locked?",
+            "nullable": true
           },
-          requestId: {
-            type: string,
-            description: Request UUID to trace bulk upload,
-            nullable: true
+          "requestId": {
+            "type": "string",
+            "description": "Request UUID to trace bulk upload",
+            "nullable": true
           },
-          isCdsFullMatched: {
-            type: boolean,
-            description: Have all commodities been matched with corresponding CDS declaration(s),
-            nullable: true
+          "isCdsFullMatched": {
+            "type": "boolean",
+            "description": "Have all commodities been matched with corresponding CDS declaration(s)",
+            "nullable": true
           },
-          chedTypeVersion: {
-            type: integer,
-            description: The version of the ched type the notification was created with,
-            format: int32,
-            nullable: true
+          "chedTypeVersion": {
+            "type": "integer",
+            "description": "The version of the ched type the notification was created with",
+            "format": "int32",
+            "nullable": true
           },
-          isGMRMatched: {
-            type: boolean,
-            description: Indicates whether a CHED has been matched with a GVMS GMR via DMP,
-            nullable: true
+          "isGMRMatched": {
+            "type": "boolean",
+            "description": "Indicates whether a CHED has been matched with a GVMS GMR via DMP",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      InspectionCheck: {
-        type: object,
-        properties: {
-          type: {
-            $ref: #/components/schemas/InspectionCheckTypeEnum
+      "InspectionCheck": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InspectionCheckTypeEnum"
+              }
+            ],
+            "description": "Type of check",
+            "nullable": true
           },
-          status: {
-            $ref: #/components/schemas/InspectionCheckStatusEnum
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InspectionCheckStatusEnum"
+              }
+            ],
+            "description": "Status of the check",
+            "nullable": true
           },
-          reason: {
-            type: string,
-            description: Reason for the status if applicable,
-            nullable: true
+          "reason": {
+            "type": "string",
+            "description": "Reason for the status if applicable",
+            "nullable": true
           },
-          otherReason: {
-            type: string,
-            description: Other reason text when selected reason is 'Other',
-            nullable: true
+          "otherReason": {
+            "type": "string",
+            "description": "Other reason text when selected reason is 'Other'",
+            "nullable": true
           },
-          isSelectedForChecks: {
-            type: boolean,
-            description: Has commodity been selected for checks?,
-            nullable: true
+          "isSelectedForChecks": {
+            "type": "boolean",
+            "description": "Has commodity been selected for checks?",
+            "nullable": true
           },
-          hasChecksComplete: {
-            type: boolean,
-            description: Has commodity completed this type of check,
-            nullable: true
+          "hasChecksComplete": {
+            "type": "boolean",
+            "description": "Has commodity completed this type of check",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      InspectionCheckStatusEnum: {
-        enum: [
-          ToDo,
-          Compliant,
-          AutoCleared,
-          NonCompliant,
-          NotInspected,
-          ToBeInspected,
-          Hold
+      "InspectionCheckStatusEnum": {
+        "enum": [
+          "ToDo",
+          "Compliant",
+          "AutoCleared",
+          "NonCompliant",
+          "NotInspected",
+          "ToBeInspected",
+          "Hold"
         ],
-        type: string
+        "type": "string"
       },
-      InspectionCheckTypeEnum: {
-        enum: [
-          PhsiDocument,
-          PhsiIdentity,
-          PhsiPhysical,
-          Hmi
+      "InspectionCheckTypeEnum": {
+        "enum": [
+          "PhsiDocument",
+          "PhsiIdentity",
+          "PhsiPhysical",
+          "Hmi"
         ],
-        type: string
+        "type": "string"
       },
-      InspectionOverride: {
-        type: object,
-        properties: {
-          originalDecision: {
-            type: string,
-            description: Original inspection decision,
-            nullable: true
+      "InspectionOverride": {
+        "type": "object",
+        "properties": {
+          "originalDecision": {
+            "type": "string",
+            "description": "Original inspection decision",
+            "nullable": true
           },
-          overriddenOn: {
-            type: string,
-            description: The time the risk decision is overridden,
-            format: date-time,
-            nullable: true
+          "overriddenOn": {
+            "type": "string",
+            "description": "The time the risk decision is overridden",
+            "format": "date-time",
+            "nullable": true
           },
-          overriddenBy: {
-            $ref: #/components/schemas/UserInformation
+          "overriddenBy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserInformation"
+              }
+            ],
+            "description": "User entity who has manually overridden the inspection",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      Inspector: {
-        type: object,
-        properties: {
-          name: {
-            type: string,
-            description: Name of inspector,
-            nullable: true
+      "Inspector": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of inspector",
+            "nullable": true
           },
-          phone: {
-            type: string,
-            description: Phone number of inspector,
-            nullable: true
+          "phone": {
+            "type": "string",
+            "description": "Phone number of inspector",
+            "nullable": true
           },
-          email: {
-            type: string,
-            description: Email address of inspector,
-            nullable: true
+          "email": {
+            "type": "string",
+            "description": "Email address of inspector",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      InternationalTelephone: {
-        type: object,
-        properties: {
-          countryCode: {
-            type: string,
-            description: Country code of phone number,
-            nullable: true
+      "InternationalTelephone": {
+        "type": "object",
+        "properties": {
+          "countryCode": {
+            "type": "string",
+            "description": "Country code of phone number",
+            "nullable": true
           },
-          subscriberNumber: {
-            type: string,
-            description: Phone number,
-            nullable: true
+          "subscriberNumber": {
+            "type": "string",
+            "description": "Phone number",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      JourneyRiskCategorisationResult: {
-        type: object,
-        properties: {
-          riskLevel: {
-            $ref: #/components/schemas/JourneyRiskCategorisationResultRiskLevelEnum
+      "JourneyRiskCategorisationResult": {
+        "type": "object",
+        "properties": {
+          "riskLevel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JourneyRiskCategorisationResultRiskLevelEnum"
+              }
+            ],
+            "description": "Risk Level is defined using enum values High,Medium,Low",
+            "nullable": true
           },
-          riskLevelMethod: {
-            $ref: #/components/schemas/JourneyRiskCategorisationResultRiskLevelMethodEnum
+          "riskLevelMethod": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JourneyRiskCategorisationResultRiskLevelMethodEnum"
+              }
+            ],
+            "description": "Indicator of whether the risk level was determined by the system or by the user",
+            "nullable": true
           },
-          riskLevelSetFor: {
-            type: string,
-            description: The date and time the risk level has been set for a notification,
-            format: date-time,
-            nullable: true
+          "riskLevelSetFor": {
+            "type": "string",
+            "description": "The date and time the risk level has been set for a notification",
+            "format": "date-time",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      JourneyRiskCategorisationResultRiskLevelEnum: {
-        enum: [
-          High,
-          Medium,
-          Low
+      "JourneyRiskCategorisationResultRiskLevelEnum": {
+        "enum": [
+          "High",
+          "Medium",
+          "Low"
         ],
-        type: string
+        "type": "string"
       },
-      JourneyRiskCategorisationResultRiskLevelMethodEnum: {
-        enum: [
-          System,
-          User
+      "JourneyRiskCategorisationResultRiskLevelMethodEnum": {
+        "enum": [
+          "System",
+          "User"
         ],
-        type: string
+        "type": "string"
       },
-      LaboratoryTestResult: {
-        type: object,
-        properties: {
-          sampleUseByDate: {
-            type: string,
-            description: When sample was used,
-            nullable: true
+      "LaboratoryTestResult": {
+        "type": "object",
+        "properties": {
+          "sampleUseByDate": {
+            "type": "string",
+            "description": "When sample was used",
+            "nullable": true
           },
-          releasedOn: {
-            type: string,
-            description: When it was released,
-            format: date-time,
-            nullable: true
+          "releasedOn": {
+            "type": "string",
+            "description": "When it was released",
+            "format": "date-time",
+            "nullable": true
           },
-          laboratoryTestMethod: {
-            type: string,
-            description: Laboratory test method,
-            nullable: true
+          "laboratoryTestMethod": {
+            "type": "string",
+            "description": "Laboratory test method",
+            "nullable": true
           },
-          results: {
-            type: string,
-            description: Result of test,
-            nullable: true
+          "results": {
+            "type": "string",
+            "description": "Result of test",
+            "nullable": true
           },
-          conclusion: {
-            $ref: #/components/schemas/LaboratoryTestResultConclusionEnum
+          "conclusion": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LaboratoryTestResultConclusionEnum"
+              }
+            ],
+            "description": "Conclusion of laboratory test",
+            "nullable": true
           },
-          labTestCreatedOn: {
-            type: string,
-            description: Date of lab test created in IPAFFS,
-            format: date-time,
-            nullable: true
+          "labTestCreatedOn": {
+            "type": "string",
+            "description": "Date of lab test created in IPAFFS",
+            "format": "date-time",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      LaboratoryTestResultConclusionEnum: {
-        enum: [
-          Satisfactory,
-          NotSatisfactory,
-          NotInterpretable,
-          Pending
+      "LaboratoryTestResultConclusionEnum": {
+        "enum": [
+          "Satisfactory",
+          "NotSatisfactory",
+          "NotInterpretable",
+          "Pending"
         ],
-        type: string
+        "type": "string"
       },
-      LaboratoryTests: {
-        type: object,
-        properties: {
-          testedOn: {
-            type: string,
-            description: Date of tests,
-            format: date-time,
-            nullable: true
+      "LaboratoryTests": {
+        "type": "object",
+        "properties": {
+          "testedOn": {
+            "type": "string",
+            "description": "Date of tests",
+            "format": "date-time",
+            "nullable": true
           },
-          testReason: {
-            $ref: #/components/schemas/LaboratoryTestsTestReasonEnum
+          "testReason": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LaboratoryTestsTestReasonEnum"
+              }
+            ],
+            "description": "Reason for test",
+            "nullable": true
           },
-          singleLaboratoryTests: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/SingleLaboratoryTest
+          "singleLaboratoryTests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SingleLaboratoryTest"
             },
-            description: List of details of individual tests performed or to be performed,
-            nullable: true
+            "description": "List of details of individual tests performed or to be performed",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      LaboratoryTestsTestReasonEnum: {
-        enum: [
-          Random,
-          Suspicious,
-          ReEnforced,
-          IntensifiedControls,
-          Required,
-          LatentInfectionSampling
+      "LaboratoryTestsTestReasonEnum": {
+        "enum": [
+          "Random",
+          "Suspicious",
+          "ReEnforced",
+          "IntensifiedControls",
+          "Required",
+          "LatentInfectionSampling"
         ],
-        type: string
+        "type": "string"
       },
-      MeansOfTransport: {
-        type: object,
-        properties: {
-          type: {
-            $ref: #/components/schemas/MeansOfTransportTypeEnum
+      "MeansOfTransport": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MeansOfTransportTypeEnum"
+              }
+            ],
+            "description": "Type of transport",
+            "nullable": true
           },
-          document: {
-            type: string,
-            description: Document for transport,
-            nullable: true
+          "document": {
+            "type": "string",
+            "description": "Document for transport",
+            "nullable": true
           },
-          id: {
-            type: string,
-            description: ID of transport,
-            nullable: true
+          "id": {
+            "type": "string",
+            "description": "ID of transport",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      MeansOfTransportTypeEnum: {
-        enum: [
-          Aeroplane,
-          RoadVehicle,
-          RailwayWagon,
-          Ship,
-          Other,
-          RoadVehicleAeroplane,
-          ShipRailwayWagon,
-          ShipRoadVehicle
+      "MeansOfTransportTypeEnum": {
+        "enum": [
+          "Aeroplane",
+          "RoadVehicle",
+          "RailwayWagon",
+          "Ship",
+          "Other",
+          "RoadVehicleAeroplane",
+          "ShipRailwayWagon",
+          "ShipRoadVehicle"
         ],
-        type: string
+        "type": "string"
       },
-      NominatedContact: {
-        type: object,
-        properties: {
-          name: {
-            type: string,
-            description: Name of nominated contact,
-            nullable: true
+      "NominatedContact": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of nominated contact",
+            "nullable": true
           },
-          email: {
-            type: string,
-            description: Email address of nominated contact,
-            nullable: true
+          "email": {
+            "type": "string",
+            "description": "Email address of nominated contact",
+            "nullable": true
           },
-          telephone: {
-            type: string,
-            description: Telephone number of nominated contact,
-            nullable: true
+          "telephone": {
+            "type": "string",
+            "description": "Telephone number of nominated contact",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      OfficialInspector: {
-        type: object,
-        properties: {
-          firstName: {
-            type: string,
-            description: First name of inspector,
-            nullable: true
+      "OfficialInspector": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "description": "First name of inspector",
+            "nullable": true
           },
-          lastName: {
-            type: string,
-            description: Last name of inspector,
-            nullable: true
+          "lastName": {
+            "type": "string",
+            "description": "Last name of inspector",
+            "nullable": true
           },
-          email: {
-            type: string,
-            description: Email of inspector,
-            nullable: true
+          "email": {
+            "type": "string",
+            "description": "Email of inspector",
+            "nullable": true
           },
-          phone: {
-            type: string,
-            description: Phone number of inspector,
-            nullable: true
+          "phone": {
+            "type": "string",
+            "description": "Phone number of inspector",
+            "nullable": true
           },
-          fax: {
-            type: string,
-            description: Fax number of inspector,
-            nullable: true
+          "fax": {
+            "type": "string",
+            "description": "Fax number of inspector",
+            "nullable": true
           },
-          address: {
-            $ref: #/components/schemas/Address
+          "address": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Address"
+              }
+            ],
+            "description": "Address of inspector",
+            "nullable": true
           },
-          signed: {
-            type: string,
-            description: Date of sign,
-            nullable: true
+          "signed": {
+            "type": "string",
+            "description": "Date of sign",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      OfficialVeterinarian: {
-        type: object,
-        properties: {
-          firstName: {
-            type: string,
-            description: First name of official veterinarian,
-            nullable: true
+      "OfficialVeterinarian": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "description": "First name of official veterinarian",
+            "nullable": true
           },
-          lastName: {
-            type: string,
-            description: Last name of official veterinarian,
-            nullable: true
+          "lastName": {
+            "type": "string",
+            "description": "Last name of official veterinarian",
+            "nullable": true
           },
-          email: {
-            type: string,
-            description: Email address of official veterinarian,
-            nullable: true
+          "email": {
+            "type": "string",
+            "description": "Email address of official veterinarian",
+            "nullable": true
           },
-          phone: {
-            type: string,
-            description: Phone number of official veterinarian,
-            nullable: true
+          "phone": {
+            "type": "string",
+            "description": "Phone number of official veterinarian",
+            "nullable": true
           },
-          fax: {
-            type: string,
-            description: Fax number of official veterinarian,
-            nullable: true
+          "fax": {
+            "type": "string",
+            "description": "Fax number of official veterinarian",
+            "nullable": true
           },
-          signed: {
-            type: string,
-            description: Date of sign,
-            nullable: true
+          "signed": {
+            "type": "string",
+            "description": "Date of sign",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      PartOne: {
-        type: object,
-        properties: {
-          personResponsible: {
-            $ref: #/components/schemas/Party
+      "PartOne": {
+        "type": "object",
+        "properties": {
+          "personResponsible": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Party"
+              }
+            ],
+            "description": "The individual who has submitted the notification",
+            "nullable": true
           },
-          consignmentArrived: {
-            type: boolean,
-            description: Has the consignment arrived at the BCP?,
-            nullable: true
+          "consignmentArrived": {
+            "type": "boolean",
+            "description": "Has the consignment arrived at the BCP?",
+            "nullable": true
           },
-          consignor: {
-            $ref: #/components/schemas/EconomicOperator
+          "consignor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Person or Company that sends shipment",
+            "nullable": true
           },
-          packer: {
-            $ref: #/components/schemas/EconomicOperator
+          "packer": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Person or Company that packs the shipment",
+            "nullable": true
           },
-          consignee: {
-            $ref: #/components/schemas/EconomicOperator
+          "consignee": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Person or Company that receives shipment",
+            "nullable": true
           },
-          importer: {
-            $ref: #/components/schemas/EconomicOperator
+          "importer": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Person or Company that is importing the consignment",
+            "nullable": true
           },
-          placeOfDestination: {
-            $ref: #/components/schemas/EconomicOperator
+          "placeOfDestination": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Where the shipment is to be sent? For IMP minimum 48 hour accommodation/holding location.",
+            "nullable": true
           },
-          pod: {
-            $ref: #/components/schemas/EconomicOperator
+          "pod": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "A temporary place of destination for plants",
+            "nullable": true
           },
-          cphNumber: {
-            type: string,
-            description: Charity Parish Holding number,
-            nullable: true
+          "cphNumber": {
+            "type": "string",
+            "description": "Charity Parish Holding number",
+            "nullable": true
           },
-          isCatchCertificateRequired: {
-            type: boolean,
-            description: Is this catch certificate required?,
-            nullable: true
+          "isCatchCertificateRequired": {
+            "type": "boolean",
+            "description": "Is this catch certificate required?",
+            "nullable": true
           },
-          isGvmsRoute: {
-            type: boolean,
-            description: Is GVMS route?,
-            nullable: true
+          "isGvmsRoute": {
+            "type": "boolean",
+            "description": "Is GVMS route?",
+            "nullable": true
           },
-          purpose: {
-            $ref: #/components/schemas/Purpose
+          "purpose": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Purpose"
+              }
+            ],
+            "description": "Purpose of consignment details",
+            "nullable": true
           },
-          pointOfEntry: {
-            type: string,
-            description: Either a Border-Inspection-Post or Designated-Point-Of-Entry, e.g. GBFXT1,
-            nullable: true
+          "pointOfEntry": {
+            "type": "string",
+            "description": "Either a Border-Inspection-Post or Designated-Point-Of-Entry, e.g. GBFXT1",
+            "nullable": true
           },
-          pointOfEntryControlPoint: {
-            type: string,
-            description: A control point at the point of entry,
-            nullable: true
+          "pointOfEntryControlPoint": {
+            "type": "string",
+            "description": "A control point at the point of entry",
+            "nullable": true
           },
-          meansOfTransport: {
-            $ref: #/components/schemas/MeansOfTransport
+          "meansOfTransport": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MeansOfTransport"
+              }
+            ],
+            "description": "How consignment is transported after BIP",
+            "nullable": true
           },
-          transporter: {
-            $ref: #/components/schemas/EconomicOperator
+          "transporter": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Transporter of consignment details",
+            "nullable": true
           },
-          transporterDetailsRequired: {
-            type: boolean,
-            description: Are transporter details required for this consignment,
-            nullable: true
+          "transporterDetailsRequired": {
+            "type": "boolean",
+            "description": "Are transporter details required for this consignment",
+            "nullable": true
           },
-          meansOfTransportFromEntryPoint: {
-            $ref: #/components/schemas/MeansOfTransport
+          "meansOfTransportFromEntryPoint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MeansOfTransport"
+              }
+            ],
+            "description": "Transport to BIP",
+            "nullable": true
           },
-          estimatedJourneyTimeInMinutes: {
-            type: number,
-            description: Estimated journey time in minutes to point of entry,
-            format: double,
-            nullable: true
+          "estimatedJourneyTimeInMinutes": {
+            "type": "number",
+            "description": "Estimated journey time in minutes to point of entry",
+            "format": "double",
+            "nullable": true
           },
-          veterinaryInformation: {
-            $ref: #/components/schemas/VeterinaryInformation
+          "veterinaryInformation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VeterinaryInformation"
+              }
+            ],
+            "description": "Part 1 - Holds the information related to veterinary checks and details",
+            "nullable": true
           },
-          importerLocalReferenceNumber: {
-            type: string,
-            description: Reference number added by the importer,
-            nullable: true
+          "importerLocalReferenceNumber": {
+            "type": "string",
+            "description": "Reference number added by the importer",
+            "nullable": true
           },
-          route: {
-            $ref: #/components/schemas/Route
+          "route": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Route"
+              }
+            ],
+            "description": "Contains countries and transfer points that consignment is going through",
+            "nullable": true
           },
-          submittedOn: {
-            type: string,
-            description: Date and time when the notification was submitted,
-            format: date-time,
-            nullable: true
+          "submittedOn": {
+            "type": "string",
+            "description": "Date and time when the notification was submitted",
+            "format": "date-time",
+            "nullable": true
           },
-          submittedBy: {
-            $ref: #/components/schemas/UserInformation
+          "submittedBy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserInformation"
+              }
+            ],
+            "description": "Information about user who submitted notification",
+            "nullable": true
           },
-          consignmentValidations: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/ValidationMessageCode
+          "consignmentValidations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationMessageCode"
             },
-            description: Validation messages for whole notification,
-            nullable: true
+            "description": "Validation messages for whole notification",
+            "nullable": true
           },
-          portOfEntry: {
-            type: string,
-            description: Entry port for EU Import notification.,
-            nullable: true
+          "portOfEntry": {
+            "type": "string",
+            "description": "Entry port for EU Import notification.",
+            "nullable": true
           },
-          portOfExit: {
-            type: string,
-            description: Exit Port for EU Import Notification.,
-            nullable: true
+          "portOfExit": {
+            "type": "string",
+            "description": "Exit Port for EU Import Notification.",
+            "nullable": true
           },
-          exitedPortOfOn: {
-            type: string,
-            description: Date of Port Exit for EU Import Notification.,
-            format: date-time,
-            nullable: true
+          "exitedPortOfOn": {
+            "type": "string",
+            "description": "Date of Port Exit for EU Import Notification.",
+            "format": "date-time",
+            "nullable": true
           },
-          contactDetails: {
-            $ref: #/components/schemas/ContactDetails
+          "contactDetails": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactDetails"
+              }
+            ],
+            "description": "Person to be contacted if there is an issue with the consignment",
+            "nullable": true
           },
-          nominatedContacts: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/NominatedContact
+          "nominatedContacts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NominatedContact"
             },
-            description: List of nominated contacts to receive text and email notifications,
-            nullable: true
+            "description": "List of nominated contacts to receive text and email notifications",
+            "nullable": true
           },
-          originalEstimatedOn: {
-            type: string,
-            description: Original estimated date time of arrival,
-            format: date-time,
-            nullable: true
+          "originalEstimatedOn": {
+            "type": "string",
+            "description": "Original estimated date time of arrival",
+            "format": "date-time",
+            "nullable": true
           },
-          billingInformation: {
-            $ref: #/components/schemas/BillingInformation
+          "billingInformation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BillingInformation"
+              }
+            ],
+            "nullable": true
           },
-          isChargeable: {
-            type: boolean,
-            description: Indicates whether CUC applies to the notification,
-            nullable: true
+          "isChargeable": {
+            "type": "boolean",
+            "description": "Indicates whether CUC applies to the notification",
+            "nullable": true
           },
-          wasChargeable: {
-            type: boolean,
-            description: Indicates whether CUC previously applied to the notification,
-            nullable: true
+          "wasChargeable": {
+            "type": "boolean",
+            "description": "Indicates whether CUC previously applied to the notification",
+            "nullable": true
           },
-          commonUserCharge: {
-            $ref: #/components/schemas/CommonUserCharge
+          "commonUserCharge": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommonUserCharge"
+              }
+            ],
+            "nullable": true
           },
-          provideCtcMrn: {
-            $ref: #/components/schemas/PartOneProvideCtcMrnEnum
+          "provideCtcMrn": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartOneProvideCtcMrnEnum"
+              }
+            ],
+            "description": "When the NCTS MRN will be added for the Common Transit Convention (CTC)",
+            "nullable": true
           },
-          arrivesAt: {
-            type: string,
-            description: DateTime,
-            format: date-time,
-            nullable: true
+          "arrivesAt": {
+            "type": "string",
+            "description": "DateTime",
+            "format": "date-time",
+            "nullable": true
           },
-          departedOn: {
-            type: string,
-            description: DateTime,
-            format: date-time,
-            nullable: true
+          "departedOn": {
+            "type": "string",
+            "description": "DateTime",
+            "format": "date-time",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      PartOneProvideCtcMrnEnum: {
-        enum: [
-          Yes,
-          YesAddLater,
-          No
+      "PartOneProvideCtcMrnEnum": {
+        "enum": [
+          "Yes",
+          "YesAddLater",
+          "No"
         ],
-        type: string
+        "type": "string"
       },
-      PartThree: {
-        type: object,
-        properties: {
-          controlStatus: {
-            $ref: #/components/schemas/PartThreeControlStatusEnum
+      "PartThree": {
+        "type": "object",
+        "properties": {
+          "controlStatus": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartThreeControlStatusEnum"
+              }
+            ],
+            "description": "Control status enum",
+            "nullable": true
           },
-          control: {
-            $ref: #/components/schemas/Control
+          "control": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Control"
+              }
+            ],
+            "description": "Control details",
+            "nullable": true
           },
-          consignmentValidations: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/ValidationMessageCode
+          "consignmentValidations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationMessageCode"
             },
-            description: Validation messages for Part 3 - Control,
-            nullable: true
+            "description": "Validation messages for Part 3 - Control",
+            "nullable": true
           },
-          sealCheckRequired: {
-            type: boolean,
-            description: Is the seal check required,
-            nullable: true
+          "sealCheckRequired": {
+            "type": "boolean",
+            "description": "Is the seal check required",
+            "nullable": true
           },
-          sealCheck: {
-            $ref: #/components/schemas/SealCheck
+          "sealCheck": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SealCheck"
+              }
+            ],
+            "description": "Seal check details",
+            "nullable": true
           },
-          sealCheckOverride: {
-            $ref: #/components/schemas/InspectionOverride
+          "sealCheckOverride": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InspectionOverride"
+              }
+            ],
+            "description": "Seal check override details",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      PartThreeControlStatusEnum: {
-        enum: [
-          Required,
-          Completed
+      "PartThreeControlStatusEnum": {
+        "enum": [
+          "Required",
+          "Completed"
         ],
-        type: string
+        "type": "string"
       },
-      PartTwo: {
-        type: object,
-        properties: {
-          decision: {
-            $ref: #/components/schemas/Decision
+      "PartTwo": {
+        "type": "object",
+        "properties": {
+          "decision": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Decision"
+              }
+            ],
+            "description": "Decision on the consignment",
+            "nullable": true
           },
-          consignmentCheck: {
-            $ref: #/components/schemas/ConsignmentCheck
+          "consignmentCheck": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConsignmentCheck"
+              }
+            ],
+            "description": "Consignment check",
+            "nullable": true
           },
-          impactOfTransportOnAnimals: {
-            $ref: #/components/schemas/ImpactOfTransportOnAnimals
+          "impactOfTransportOnAnimals": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImpactOfTransportOnAnimals"
+              }
+            ],
+            "description": "Checks of impact of transport on animals",
+            "nullable": true
           },
-          laboratoryTestsRequired: {
-            type: boolean,
-            description: Are laboratory tests required,
-            nullable: true
+          "laboratoryTestsRequired": {
+            "type": "boolean",
+            "description": "Are laboratory tests required",
+            "nullable": true
           },
-          laboratoryTests: {
-            $ref: #/components/schemas/LaboratoryTests
+          "laboratoryTests": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LaboratoryTests"
+              }
+            ],
+            "description": "Laboratory tests information details",
+            "nullable": true
           },
-          resealedContainersIncluded: {
-            type: boolean,
-            description: Are the containers resealed,
-            nullable: true
+          "resealedContainersIncluded": {
+            "type": "boolean",
+            "description": "Are the containers resealed",
+            "nullable": true
           },
-          resealedContainersMappings: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/SealContainer
+          "resealedContainersMappings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SealContainer"
             },
-            description: Resealed containers information details,
-            nullable: true
+            "description": "Resealed containers information details",
+            "nullable": true
           },
-          controlAuthority: {
-            $ref: #/components/schemas/ControlAuthority
+          "controlAuthority": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ControlAuthority"
+              }
+            ],
+            "description": "Control Authority information details",
+            "nullable": true
           },
-          controlledDestination: {
-            $ref: #/components/schemas/EconomicOperator
+          "controlledDestination": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Controlled destination",
+            "nullable": true
           },
-          bipLocalReferenceNumber: {
-            type: string,
-            description: Local reference number at BIP,
-            nullable: true
+          "bipLocalReferenceNumber": {
+            "type": "string",
+            "description": "Local reference number at BIP",
+            "nullable": true
           },
-          signedOnBehalfOf: {
-            type: string,
-            description: Part 2 - Sometimes other user can sign decision on behalf of another user,
-            nullable: true
+          "signedOnBehalfOf": {
+            "type": "string",
+            "description": "Part 2 - Sometimes other user can sign decision on behalf of another user",
+            "nullable": true
           },
-          onwardTransportation: {
-            type: string,
-            description: Onward transportation,
-            nullable: true
+          "onwardTransportation": {
+            "type": "string",
+            "description": "Onward transportation",
+            "nullable": true
           },
-          consignmentValidations: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/ValidationMessageCode
+          "consignmentValidations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationMessageCode"
             },
-            description: Validation messages for Part 2 - Decision,
-            nullable: true
+            "description": "Validation messages for Part 2 - Decision",
+            "nullable": true
           },
-          checkedOn: {
-            type: string,
-            description: User entered date when the checks were completed,
-            format: date-time,
-            nullable: true
+          "checkedOn": {
+            "type": "string",
+            "description": "User entered date when the checks were completed",
+            "format": "date-time",
+            "nullable": true
           },
-          accompanyingDocuments: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/AccompanyingDocument
+          "accompanyingDocuments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AccompanyingDocument"
             },
-            description: Accompanying documents,
-            nullable: true
+            "description": "Accompanying documents",
+            "nullable": true
           },
-          phsiAutoCleared: {
-            type: boolean,
-            description: Have the PHSI regulated commodities been auto cleared?,
-            nullable: true
+          "phsiAutoCleared": {
+            "type": "boolean",
+            "description": "Have the PHSI regulated commodities been auto cleared?",
+            "nullable": true
           },
-          hmiAutoCleared: {
-            type: boolean,
-            description: Have the HMI regulated commodities been auto cleared?,
-            nullable: true
+          "hmiAutoCleared": {
+            "type": "boolean",
+            "description": "Have the HMI regulated commodities been auto cleared?",
+            "nullable": true
           },
-          inspectionRequired: {
-            type: string,
-            description: Inspection required,
-            nullable: true
+          "inspectionRequired": {
+            "type": "string",
+            "description": "Inspection required",
+            "nullable": true
           },
-          inspectionOverride: {
-            $ref: #/components/schemas/InspectionOverride
+          "inspectionOverride": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InspectionOverride"
+              }
+            ],
+            "description": "Details about the manual inspection override",
+            "nullable": true
           },
-          autoClearedOn: {
-            type: string,
-            description: Date of autoclearance,
-            format: date-time,
-            nullable: true
+          "autoClearedOn": {
+            "type": "string",
+            "description": "Date of autoclearance",
+            "format": "date-time",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      Party: {
-        type: object,
-        properties: {
-          id: {
-            type: string,
-            description: IPAFFS ID of party,
-            nullable: true
+      "Party": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "IPAFFS ID of party",
+            "nullable": true
           },
-          name: {
-            type: string,
-            description: Name of party,
-            nullable: true
+          "name": {
+            "type": "string",
+            "description": "Name of party",
+            "nullable": true
           },
-          companyId: {
-            type: string,
-            description: Company ID,
-            nullable: true
+          "companyId": {
+            "type": "string",
+            "description": "Company ID",
+            "nullable": true
           },
-          contactId: {
-            type: string,
-            description: Contact ID (B2C),
-            nullable: true
+          "contactId": {
+            "type": "string",
+            "description": "Contact ID (B2C)",
+            "nullable": true
           },
-          companyName: {
-            type: string,
-            description: Company name,
-            nullable: true
+          "companyName": {
+            "type": "string",
+            "description": "Company name",
+            "nullable": true
           },
-          addresses: {
-            type: array,
-            items: {
-              type: string
+          "addresses": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            description: Addresses,
-            nullable: true
+            "description": "Addresses",
+            "nullable": true
           },
-          county: {
-            type: string,
-            description: County,
-            nullable: true
+          "county": {
+            "type": "string",
+            "description": "County",
+            "nullable": true
           },
-          postCode: {
-            type: string,
-            description: Post code of party,
-            nullable: true
+          "postCode": {
+            "type": "string",
+            "description": "Post code of party",
+            "nullable": true
           },
-          country: {
-            type: string,
-            description: Country of party,
-            nullable: true
+          "country": {
+            "type": "string",
+            "description": "Country of party",
+            "nullable": true
           },
-          city: {
-            type: string,
-            description: City,
-            nullable: true
+          "city": {
+            "type": "string",
+            "description": "City",
+            "nullable": true
           },
-          tracesId: {
-            type: integer,
-            description: TRACES ID,
-            format: int32,
-            nullable: true
+          "tracesId": {
+            "type": "integer",
+            "description": "TRACES ID",
+            "format": "int32",
+            "nullable": true
           },
-          type: {
-            $ref: #/components/schemas/PartyTypeEnum
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartyTypeEnum"
+              }
+            ],
+            "description": "Type of party",
+            "nullable": true
           },
-          approvalNumber: {
-            type: string,
-            description: Approval number,
-            nullable: true
+          "approvalNumber": {
+            "type": "string",
+            "description": "Approval number",
+            "nullable": true
           },
-          phone: {
-            type: string,
-            description: Phone number of party,
-            nullable: true
+          "phone": {
+            "type": "string",
+            "description": "Phone number of party",
+            "nullable": true
           },
-          fax: {
-            type: string,
-            description: Fax number of party,
-            nullable: true
+          "fax": {
+            "type": "string",
+            "description": "Fax number of party",
+            "nullable": true
           },
-          email: {
-            type: string,
-            description: Email number of party,
-            nullable: true
+          "email": {
+            "type": "string",
+            "description": "Email number of party",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      PartyTypeEnum: {
-        enum: [
-          CommercialTransporter,
-          PrivateTransporter
+      "PartyTypeEnum": {
+        "enum": [
+          "CommercialTransporter",
+          "PrivateTransporter"
         ],
-        type: string
+        "type": "string"
       },
-      Phsi: {
-        type: object,
-        properties: {
-          documentCheck: {
-            type: boolean,
-            description: Whether or not a documentary check is required for PHSI,
-            nullable: true
+      "Phsi": {
+        "type": "object",
+        "properties": {
+          "documentCheck": {
+            "type": "boolean",
+            "description": "Whether or not a documentary check is required for PHSI",
+            "nullable": true
           },
-          identityCheck: {
-            type: boolean,
-            description: Whether or not an identity check is required for PHSI,
-            nullable: true
+          "identityCheck": {
+            "type": "boolean",
+            "description": "Whether or not an identity check is required for PHSI",
+            "nullable": true
           },
-          physicalCheck: {
-            type: boolean,
-            description: Whether or not a physical check is required for PHSI,
-            nullable: true
+          "physicalCheck": {
+            "type": "boolean",
+            "description": "Whether or not a physical check is required for PHSI",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      PostalAddress: {
-        type: object,
-        properties: {
-          addressLine1: {
-            type: string,
-            description: 1st line of address,
-            nullable: true
+      "PostalAddress": {
+        "type": "object",
+        "properties": {
+          "addressLine1": {
+            "type": "string",
+            "description": "1st line of address",
+            "nullable": true
           },
-          addressLine2: {
-            type: string,
-            description: 2nd line of address,
-            nullable: true
+          "addressLine2": {
+            "type": "string",
+            "description": "2nd line of address",
+            "nullable": true
           },
-          addressLine3: {
-            type: string,
-            description: 3rd line of address,
-            nullable: true
+          "addressLine3": {
+            "type": "string",
+            "description": "3rd line of address",
+            "nullable": true
           },
-          addressLine4: {
-            type: string,
-            description: 4th line of address,
-            nullable: true
+          "addressLine4": {
+            "type": "string",
+            "description": "4th line of address",
+            "nullable": true
           },
-          county: {
-            type: string,
-            description: 3rd line of address,
-            nullable: true
+          "county": {
+            "type": "string",
+            "description": "3rd line of address",
+            "nullable": true
           },
-          cityOrTown: {
-            type: string,
-            description: City or town name,
-            nullable: true
+          "cityOrTown": {
+            "type": "string",
+            "description": "City or town name",
+            "nullable": true
           },
-          postalCode: {
-            type: string,
-            description: Post code,
-            nullable: true
+          "postalCode": {
+            "type": "string",
+            "description": "Post code",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      ProblemDetails: {
-        type: object,
-        properties: {
-          type: {
-            type: string,
-            nullable: true
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
           },
-          title: {
-            type: string,
-            nullable: true
+          "title": {
+            "type": "string",
+            "nullable": true
           },
-          status: {
-            type: integer,
-            format: int32,
-            nullable: true
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           },
-          detail: {
-            type: string,
-            nullable: true
+          "detail": {
+            "type": "string",
+            "nullable": true
           },
-          instance: {
-            type: string,
-            nullable: true
+          "instance": {
+            "type": "string",
+            "nullable": true
           }
-        }
+        },
+        "additionalProperties": { }
       },
-      Purpose: {
-        type: object,
-        properties: {
-          conformsToEU: {
-            type: boolean,
-            description: Does consignment conforms to UK laws,
-            nullable: true
+      "Purpose": {
+        "type": "object",
+        "properties": {
+          "conformsToEU": {
+            "type": "boolean",
+            "description": "Does consignment conforms to UK laws",
+            "nullable": true
           },
-          internalMarketPurpose: {
-            $ref: #/components/schemas/PurposeInternalMarketPurposeEnum
+          "internalMarketPurpose": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PurposeInternalMarketPurposeEnum"
+              }
+            ],
+            "description": "Detailed purpose of internal market purpose group",
+            "nullable": true
           },
-          thirdCountryTranshipment: {
-            type: string,
-            description: Country that consignment is transshipped through,
-            nullable: true
+          "thirdCountryTranshipment": {
+            "type": "string",
+            "description": "Country that consignment is transshipped through",
+            "nullable": true
           },
-          forNonConforming: {
-            $ref: #/components/schemas/PurposeForNonConformingEnum
+          "forNonConforming": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PurposeForNonConformingEnum"
+              }
+            ],
+            "description": "Detailed purpose for non conforming purpose group",
+            "nullable": true
           },
-          regNumber: {
-            type: string,
-            description: There are 3 types of registration number based on the purpose of consignment. Customs registration number, Free zone registration number and Shipping supplier registration number.,
-            nullable: true
+          "regNumber": {
+            "type": "string",
+            "description": "There are 3 types of registration number based on the purpose of consignment. Customs registration number, Free zone registration number and Shipping supplier registration number.",
+            "nullable": true
           },
-          shipName: {
-            type: string,
-            description: Ship name,
-            nullable: true
+          "shipName": {
+            "type": "string",
+            "description": "Ship name",
+            "nullable": true
           },
-          shipPort: {
-            type: string,
-            description: Destination Ship port,
-            nullable: true
+          "shipPort": {
+            "type": "string",
+            "description": "Destination Ship port",
+            "nullable": true
           },
-          exitBip: {
-            type: string,
-            description: Exit Border Inspection Post,
-            nullable: true
+          "exitBip": {
+            "type": "string",
+            "description": "Exit Border Inspection Post",
+            "nullable": true
           },
-          thirdCountry: {
-            type: string,
-            description: Country to which consignment is transited,
-            nullable: true
+          "thirdCountry": {
+            "type": "string",
+            "description": "Country to which consignment is transited",
+            "nullable": true
           },
-          transitThirdCountries: {
-            type: array,
-            items: {
-              type: string
+          "transitThirdCountries": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            description: Countries that consignment is transited through,
-            nullable: true
+            "description": "Countries that consignment is transited through",
+            "nullable": true
           },
-          forImportOrAdmission: {
-            $ref: #/components/schemas/PurposeForImportOrAdmissionEnum
+          "forImportOrAdmission": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PurposeForImportOrAdmissionEnum"
+              }
+            ],
+            "description": "Specification of Import or admission purpose",
+            "nullable": true
           },
-          exitDate: {
-            type: string,
-            description: Exit date when import or admission,
-            nullable: true
+          "exitDate": {
+            "type": "string",
+            "description": "Exit date when import or admission",
+            "nullable": true
           },
-          finalBip: {
-            type: string,
-            description: Final Border Inspection Post,
-            nullable: true
+          "finalBip": {
+            "type": "string",
+            "description": "Final Border Inspection Post",
+            "nullable": true
           },
-          purposeGroup: {
-            $ref: #/components/schemas/PurposePurposeGroupEnum
+          "purposeGroup": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PurposePurposeGroupEnum"
+              }
+            ],
+            "description": "Purpose group of consignment (general purpose)",
+            "nullable": true
           },
-          estimatedArrivesAtPortOfExit: {
-            type: string,
-            description: DateTime,
-            format: date-time,
-            nullable: true
+          "estimatedArrivesAtPortOfExit": {
+            "type": "string",
+            "description": "DateTime",
+            "format": "date-time",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      PurposeForImportOrAdmissionEnum: {
-        enum: [
-          DefinitiveImport,
-          HorsesReEntry,
-          TemporaryAdmissionHorses
+      "PurposeForImportOrAdmissionEnum": {
+        "enum": [
+          "DefinitiveImport",
+          "HorsesReEntry",
+          "TemporaryAdmissionHorses"
         ],
-        type: string
+        "type": "string"
       },
-      PurposeForNonConformingEnum: {
-        enum: [
-          CustomsWarehouse,
-          FreeZoneOrFreeWarehouse,
-          ShipSupplier,
-          Ship
+      "PurposeForNonConformingEnum": {
+        "enum": [
+          "CustomsWarehouse",
+          "FreeZoneOrFreeWarehouse",
+          "ShipSupplier",
+          "Ship"
         ],
-        type: string
+        "type": "string"
       },
-      PurposeInternalMarketPurposeEnum: {
-        enum: [
-          AnimalFeedingStuff,
-          HumanConsumption,
-          PharmaceuticalUse,
-          TechnicalUse,
-          Other,
-          CommercialSale,
-          CommercialSaleOrChangeOfOwnership,
-          Rescue,
-          Breeding,
-          Research,
-          RacingOrCompetition,
-          ApprovedPremisesOrBody,
-          CompanionAnimalNotForResaleOrRehoming,
-          Production,
-          Slaughter,
-          Fattening,
-          GameRestocking,
-          RegisteredHorses
+      "PurposeInternalMarketPurposeEnum": {
+        "enum": [
+          "AnimalFeedingStuff",
+          "HumanConsumption",
+          "PharmaceuticalUse",
+          "TechnicalUse",
+          "Other",
+          "CommercialSale",
+          "CommercialSaleOrChangeOfOwnership",
+          "Rescue",
+          "Breeding",
+          "Research",
+          "RacingOrCompetition",
+          "ApprovedPremisesOrBody",
+          "CompanionAnimalNotForResaleOrRehoming",
+          "Production",
+          "Slaughter",
+          "Fattening",
+          "GameRestocking",
+          "RegisteredHorses"
         ],
-        type: string
+        "type": "string"
       },
-      PurposePurposeGroupEnum: {
-        enum: [
-          ForImport,
-          ForNONConformingConsignments,
-          ForTranshipmentTo,
-          ForTransitTo3rdCountry,
-          ForReImport,
-          ForPrivateImport,
-          ForTransferTo,
-          ForImportReConformityCheck,
-          ForImportNonInternalMarket
+      "PurposePurposeGroupEnum": {
+        "enum": [
+          "ForImport",
+          "ForNONConformingConsignments",
+          "ForTranshipmentTo",
+          "ForTransitTo3rdCountry",
+          "ForReImport",
+          "ForPrivateImport",
+          "ForTransferTo",
+          "ForImportReConformityCheck",
+          "ForImportNonInternalMarket"
         ],
-        type: string
+        "type": "string"
       },
-      RiskAssessmentResult: {
-        type: object,
-        properties: {
-          commodityResults: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/CommodityRiskResult
+      "RiskAssessmentResult": {
+        "type": "object",
+        "properties": {
+          "commodityResults": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommodityRiskResult"
             },
-            description: List of risk assessed commodities,
-            nullable: true
+            "description": "List of risk assessed commodities",
+            "nullable": true
           },
-          assessedOn: {
-            type: string,
-            description: Date and time of assessment,
-            format: date-time,
-            nullable: true
+          "assessedOn": {
+            "type": "string",
+            "description": "Date and time of assessment",
+            "format": "date-time",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      Route: {
-        type: object,
-        properties: {
-          transitingStates: {
-            type: array,
-            items: {
-              type: string
+      "Route": {
+        "type": "object",
+        "properties": {
+          "transitingStates": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            nullable: true
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      SealCheck: {
-        type: object,
-        properties: {
-          satisfactory: {
-            type: boolean,
-            description: Is seal check satisfactory,
-            nullable: true
+      "SealCheck": {
+        "type": "object",
+        "properties": {
+          "satisfactory": {
+            "type": "boolean",
+            "description": "Is seal check satisfactory",
+            "nullable": true
           },
-          reason: {
-            type: string,
-            description: reason for not satisfactory,
-            nullable: true
+          "reason": {
+            "type": "string",
+            "description": "reason for not satisfactory",
+            "nullable": true
           },
-          officialInspector: {
-            $ref: #/components/schemas/OfficialInspector
+          "officialInspector": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OfficialInspector"
+              }
+            ],
+            "description": "Official inspector",
+            "nullable": true
           },
-          checkedOn: {
-            type: string,
-            description: date and time of seal check,
-            format: date-time,
-            nullable: true
+          "checkedOn": {
+            "type": "string",
+            "description": "date and time of seal check",
+            "format": "date-time",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      SealContainer: {
-        type: object,
-        properties: {
-          sealNumber: {
-            type: string,
-            nullable: true
+      "SealContainer": {
+        "type": "object",
+        "properties": {
+          "sealNumber": {
+            "type": "string",
+            "nullable": true
           },
-          containerNumber: {
-            type: string,
-            nullable: true
+          "containerNumber": {
+            "type": "string",
+            "nullable": true
           },
-          officialSeal: {
-            type: boolean,
-            nullable: true
+          "officialSeal": {
+            "type": "boolean",
+            "nullable": true
           },
-          resealedSealNumber: {
-            type: string,
-            nullable: true
+          "resealedSealNumber": {
+            "type": "string",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      SingleLaboratoryTest: {
-        type: object,
-        properties: {
-          commodityCode: {
-            type: string,
-            description: Commodity code for which lab test was ordered,
-            nullable: true
+      "SingleLaboratoryTest": {
+        "type": "object",
+        "properties": {
+          "commodityCode": {
+            "type": "string",
+            "description": "Commodity code for which lab test was ordered",
+            "nullable": true
           },
-          speciesId: {
-            type: integer,
-            description: Species id of commodity for which lab test was ordered,
-            format: int32,
-            nullable: true
+          "speciesId": {
+            "type": "integer",
+            "description": "Species id of commodity for which lab test was ordered",
+            "format": "int32",
+            "nullable": true
           },
-          tracesId: {
-            type: integer,
-            description: TRACES ID,
-            format: int32,
-            nullable: true
+          "tracesId": {
+            "type": "integer",
+            "description": "TRACES ID",
+            "format": "int32",
+            "nullable": true
           },
-          testName: {
-            type: string,
-            description: Test name,
-            nullable: true
+          "testName": {
+            "type": "string",
+            "description": "Test name",
+            "nullable": true
           },
-          applicant: {
-            $ref: #/components/schemas/Applicant
+          "applicant": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Applicant"
+              }
+            ],
+            "description": "Laboratory tests information details and information about laboratory",
+            "nullable": true
           },
-          laboratoryTestResult: {
-            $ref: #/components/schemas/LaboratoryTestResult
+          "laboratoryTestResult": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LaboratoryTestResult"
+              }
+            ],
+            "description": "Information about results of test",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      SplitConsignment: {
-        type: object,
-        properties: {
-          validReferenceNumber: {
-            type: string,
-            description: Reference number of the valid split consignment,
-            nullable: true
+      "SplitConsignment": {
+        "type": "object",
+        "properties": {
+          "validReferenceNumber": {
+            "type": "string",
+            "description": "Reference number of the valid split consignment",
+            "nullable": true
           },
-          rejectedReferenceNumber: {
-            type: string,
-            description: Reference number of the rejected split consignment,
-            nullable: true
+          "rejectedReferenceNumber": {
+            "type": "string",
+            "description": "Reference number of the rejected split consignment",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      UpdatedImportNotification: {
-        required: [
-          updated,
-          uri
+      "UpdatedImportNotification": {
+        "required": [
+          "updated",
+          "uri"
         ],
-        type: object,
-        properties: {
-          updated: {
-            type: string,
-            description: Date last updated. Format is ISO 8601-1:2019,
-            format: date-time
+        "type": "object",
+        "properties": {
+          "updated": {
+            "type": "string",
+            "description": "Date last updated. Format is ISO 8601-1:2019",
+            "format": "date-time"
           },
-          uri: {
-            minLength: 1,
-            pattern: ^/import-notifications/CHED(?:A|D|P|PP)\.GB\.\d{4}\.\d{7}$,
-            type: string,
-            description: Relative path to import notification,
-            example: /import-notifications/CHEDA.GB.2024.1020304
+          "uri": {
+            "minLength": 1,
+            "pattern": "^/import-notifications/CHED(?:A|D|P|PP)\\.GB\\.\\d{4}\\.\\d{7}$",
+            "type": "string",
+            "description": "Relative path to import notification",
+            "example": "/import-notifications/CHEDA.GB.2024.1020304"
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      UpdatedImportNotificationPagedResponse: {
-        required: [
-          currentPage,
-          records,
-          totalPages,
-          totalRecords
+      "UpdatedImportNotificationPagedResponse": {
+        "required": [
+          "currentPage",
+          "records",
+          "totalPages",
+          "totalRecords"
         ],
-        type: object,
-        properties: {
-          records: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/UpdatedImportNotification
+        "type": "object",
+        "properties": {
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UpdatedImportNotification"
             },
-            description: Records for current page
+            "description": "Records for current page"
           },
-          totalRecords: {
-            type: integer,
-            description: Total records across all pages,
-            format: int32
+          "totalRecords": {
+            "type": "integer",
+            "description": "Total records across all pages",
+            "format": "int32"
           },
-          currentPage: {
-            type: integer,
-            description: Current page,
-            format: int32
+          "currentPage": {
+            "type": "integer",
+            "description": "Current page",
+            "format": "int32"
           },
-          totalPages: {
-            type: integer,
-            description: Total number of pages,
-            format: int32
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number of pages",
+            "format": "int32"
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      UserInformation: {
-        type: object,
-        properties: {
-          displayName: {
-            type: string,
-            description: Display name,
-            nullable: true
+      "UserInformation": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string",
+            "description": "Display name",
+            "nullable": true
           },
-          userId: {
-            type: string,
-            description: User ID,
-            nullable: true
+          "userId": {
+            "type": "string",
+            "description": "User ID",
+            "nullable": true
           },
-          isControlUser: {
-            type: boolean,
-            description: Is this user a control,
-            nullable: true
+          "isControlUser": {
+            "type": "boolean",
+            "description": "Is this user a control",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      ValidationMessageCode: {
-        type: object,
-        properties: {
-          field: {
-            type: string,
-            description: Field,
-            nullable: true
+      "ValidationMessageCode": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "Field",
+            "nullable": true
           },
-          code: {
-            type: string,
-            description: Code,
-            nullable: true
+          "code": {
+            "type": "string",
+            "description": "Code",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       },
-      VeterinaryInformation: {
-        type: object,
-        properties: {
-          establishmentsOfOriginExternalReference: {
-            $ref: #/components/schemas/ExternalReference
+      "VeterinaryInformation": {
+        "type": "object",
+        "properties": {
+          "establishmentsOfOriginExternalReference": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalReference"
+              }
+            ],
+            "description": "External reference of approved establishments, which relates to a downstream service",
+            "nullable": true
           },
-          establishmentsOfOrigins: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/ApprovedEstablishment
+          "establishmentsOfOrigins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApprovedEstablishment"
             },
-            description: List of establishments which were approved by UK to issue veterinary documents,
-            nullable: true
+            "description": "List of establishments which were approved by UK to issue veterinary documents",
+            "nullable": true
           },
-          veterinaryDocument: {
-            type: string,
-            description: Veterinary document identification,
-            nullable: true
+          "veterinaryDocument": {
+            "type": "string",
+            "description": "Veterinary document identification",
+            "nullable": true
           },
-          veterinaryDocumentIssuedOn: {
-            type: string,
-            description: Veterinary document issue date,
-            nullable: true
+          "veterinaryDocumentIssuedOn": {
+            "type": "string",
+            "description": "Veterinary document issue date",
+            "nullable": true
           },
-          accompanyingDocumentNumbers: {
-            type: array,
-            items: {
-              type: string
+          "accompanyingDocumentNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            description: Additional documents,
-            nullable: true
+            "description": "Additional documents",
+            "nullable": true
           },
-          accompanyingDocuments: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/AccompanyingDocument
+          "accompanyingDocuments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AccompanyingDocument"
             },
-            description: Accompanying documents,
-            nullable: true
+            "description": "Accompanying documents",
+            "nullable": true
           },
-          catchCertificateAttachments: {
-            type: array,
-            items: {
-              $ref: #/components/schemas/CatchCertificateAttachment
+          "catchCertificateAttachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CatchCertificateAttachment"
             },
-            description: Catch certificate attachments,
-            nullable: true
+            "description": "Catch certificate attachments",
+            "nullable": true
           }
         },
-        additionalProperties: false
+        "additionalProperties": false
       }
     }
   },
-  tags: [
+  "tags": [
     {
-      name: Import Notifications,
-      description: Get updated import notifications for a PHA
+      "name": "Import Notifications",
+      "description": "Get updated import notifications for a PHA"
     }
   ],
-  x-tagGroups: [
+  "x-tagGroups": [
     {
-      name: Endpoints,
-      tags: [
-        Import Notifications
+      "name": "Endpoints",
+      "tags": [
+        "Import Notifications"
       ]
     }
   ]

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -213,10 +213,6 @@
   components: {
     schemas: {
       AccompanyingDocument: {
-        required: [
-          documentType,
-          externalReference
-        ],
         type: object,
         properties: {
           documentType: {
@@ -302,9 +298,6 @@
         type: string
       },
       Address: {
-        required: [
-          internationalTelephone
-        ],
         type: object,
         properties: {
           street: {
@@ -374,11 +367,6 @@
         additionalProperties: false
       },
       Applicant: {
-        required: [
-          analysisType,
-          conservationOfSample,
-          inspector
-        ],
         type: object,
         properties: {
           laboratory: {
@@ -496,9 +484,6 @@
         additionalProperties: false
       },
       BillingInformation: {
-        required: [
-          postalAddress
-        ],
         type: object,
         properties: {
           isConfirmed: {
@@ -588,10 +573,6 @@
         additionalProperties: false
       },
       ChedppNotAcceptableReason: {
-        required: [
-          commodityOrPackage,
-          reason
-        ],
         type: object,
         properties: {
           reason: {
@@ -646,9 +627,6 @@
         type: string
       },
       Commodities: {
-        required: [
-          commodityIntendedFor
-        ],
         type: object,
         properties: {
           gmsDeclarationAccepted: {
@@ -752,9 +730,6 @@
         type: string
       },
       CommodityComplement: {
-        required: [
-          riskAssesment
-        ],
         type: object,
         properties: {
           uniqueComplementId: {
@@ -865,14 +840,6 @@
         additionalProperties: false
       },
       CommodityRiskResult: {
-        required: [
-          exitRiskDecision,
-          hmiDecision,
-          phsi,
-          phsiClassification,
-          phsiDecision,
-          riskDecision
-        ],
         type: object,
         properties: {
           riskDecision: {
@@ -972,11 +939,6 @@
         additionalProperties: false
       },
       ConsignmentCheck: {
-        required: [
-          identityCheckNotDoneReason,
-          identityCheckType,
-          physicalCheckNotDoneReason
-        ],
         type: object,
         properties: {
           euStandard: {
@@ -1106,12 +1068,6 @@
         additionalProperties: false
       },
       Control: {
-        required: [
-          consignmentLeave,
-          detailsOnReExport,
-          feedbackInformation,
-          officialInspector
-        ],
         type: object,
         properties: {
           feedbackInformation: {
@@ -1130,10 +1086,6 @@
         additionalProperties: false
       },
       ControlAuthority: {
-        required: [
-          iuuOption,
-          officialVeterinarian
-        ],
         type: object,
         properties: {
           officialVeterinarian: {
@@ -1182,22 +1134,6 @@
         type: string
       },
       Decision: {
-        required: [
-          decisionEnum,
-          definitiveImportPurpose,
-          detailsOfControlledDestinations,
-          freeCirculationPurpose,
-          ifChanneledOption,
-          notAcceptableAction,
-          notAcceptableActionDestructionReason,
-          notAcceptableActionEntryRefusalReason,
-          notAcceptableActionIndustrialProcessingReason,
-          notAcceptableActionQuarantineImposedReason,
-          notAcceptableActionReDispatchReason,
-          notAcceptableActionSpecialTreatmentReason,
-          notAcceptableActionUseForOtherPurposesReason,
-          specificWarehouseNonConformingConsignment
-        ],
         type: object,
         properties: {
           consignmentAcceptable: {
@@ -1501,9 +1437,6 @@
         type: string
       },
       DetailsOnReExport: {
-        required: [
-          transportType
-        ],
         type: object,
         properties: {
           date: {
@@ -1551,11 +1484,6 @@
         type: string
       },
       EconomicOperator: {
-        required: [
-          address,
-          status,
-          type
-        ],
         type: object,
         properties: {
           id: {
@@ -1628,9 +1556,6 @@
         type: string
       },
       ExternalReference: {
-        required: [
-          system
-        ],
         type: object,
         properties: {
           system: {
@@ -1669,9 +1594,6 @@
         type: string
       },
       FeedbackInformation: {
-        required: [
-          authorityType
-        ],
         type: object,
         properties: {
           authorityType: {
@@ -1772,18 +1694,7 @@
       },
       ImportNotificationsResponse: {
         required: [
-          commoditiesSummary,
           created,
-          decisionBy,
-          importNotificationType,
-          journeyRiskCategorisation,
-          lastUpdatedBy,
-          partOne,
-          partThree,
-          partTwo,
-          riskAssessment,
-          splitConsignment,
-          status,
           updated
         ],
         type: object,
@@ -1959,10 +1870,6 @@
         additionalProperties: false
       },
       InspectionCheck: {
-        required: [
-          status,
-          type
-        ],
         type: object,
         properties: {
           type: {
@@ -2016,9 +1923,6 @@
         type: string
       },
       InspectionOverride: {
-        required: [
-          overriddenBy
-        ],
         type: object,
         properties: {
           originalDecision: {
@@ -2076,10 +1980,6 @@
         additionalProperties: false
       },
       JourneyRiskCategorisationResult: {
-        required: [
-          riskLevel,
-          riskLevelMethod
-        ],
         type: object,
         properties: {
           riskLevel: {
@@ -2113,9 +2013,6 @@
         type: string
       },
       LaboratoryTestResult: {
-        required: [
-          conclusion
-        ],
         type: object,
         properties: {
           sampleUseByDate: {
@@ -2161,9 +2058,6 @@
         type: string
       },
       LaboratoryTests: {
-        required: [
-          testReason
-        ],
         type: object,
         properties: {
           testedOn: {
@@ -2198,9 +2092,6 @@
         type: string
       },
       MeansOfTransport: {
-        required: [
-          type
-        ],
         type: object,
         properties: {
           type: {
@@ -2254,9 +2145,6 @@
         additionalProperties: false
       },
       OfficialInspector: {
-        required: [
-          address
-        ],
         type: object,
         properties: {
           firstName: {
@@ -2332,26 +2220,6 @@
         additionalProperties: false
       },
       PartOne: {
-        required: [
-          billingInformation,
-          commonUserCharge,
-          consignee,
-          consignor,
-          contactDetails,
-          importer,
-          meansOfTransport,
-          meansOfTransportFromEntryPoint,
-          packer,
-          personResponsible,
-          placeOfDestination,
-          pod,
-          provideCtcMrn,
-          purpose,
-          route,
-          submittedBy,
-          transporter,
-          veterinaryInformation
-        ],
         type: object,
         properties: {
           personResponsible: {
@@ -2532,12 +2400,6 @@
         type: string
       },
       PartThree: {
-        required: [
-          control,
-          controlStatus,
-          sealCheck,
-          sealCheckOverride
-        ],
         type: object,
         properties: {
           controlStatus: {
@@ -2576,15 +2438,6 @@
         type: string
       },
       PartTwo: {
-        required: [
-          consignmentCheck,
-          controlAuthority,
-          controlledDestination,
-          decision,
-          impactOfTransportOnAnimals,
-          inspectionOverride,
-          laboratoryTests
-        ],
         type: object,
         properties: {
           decision: {
@@ -2688,9 +2541,6 @@
         additionalProperties: false
       },
       Party: {
-        required: [
-          type
-        ],
         type: object,
         properties: {
           id: {
@@ -2874,12 +2724,6 @@
         }
       },
       Purpose: {
-        required: [
-          forImportOrAdmission,
-          forNonConforming,
-          internalMarketPurpose,
-          purposeGroup
-        ],
         type: object,
         properties: {
           conformsToEU: {
@@ -3044,9 +2888,6 @@
         additionalProperties: false
       },
       SealCheck: {
-        required: [
-          officialInspector
-        ],
         type: object,
         properties: {
           satisfactory: {
@@ -3094,10 +2935,6 @@
         additionalProperties: false
       },
       SingleLaboratoryTest: {
-        required: [
-          applicant,
-          laboratoryTestResult
-        ],
         type: object,
         properties: {
           commodityCode: {
@@ -3241,9 +3078,6 @@
         additionalProperties: false
       },
       VeterinaryInformation: {
-        required: [
-          establishmentsOfOriginExternalReference
-        ],
         type: object,
         properties: {
           establishmentsOfOriginExternalReference: {

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.cs
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.cs
@@ -10,7 +10,7 @@ public class OpenApiTests(WebApplicationFactory<Program> factory) : IClassFixtur
         var client = factory.CreateClient();
         var response = await client.GetStringAsync("/.well-known/openapi/v1/openapi.json");
 
-        await VerifyJson(response);
+        await Verify(response);
     }
 
     [Fact]

--- a/tools/SchemaToCSharp/cdms-public-openapi-v0.1.json
+++ b/tools/SchemaToCSharp/cdms-public-openapi-v0.1.json
@@ -88,7 +88,17 @@
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SyncPeriod"
+              "enum": [
+                "Today",
+                "LastMonth",
+                "ThisMonth",
+                "All"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/SyncPeriod"
+                }
+              ]
             }
           }
         ],
@@ -122,7 +132,17 @@
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SyncPeriod"
+              "enum": [
+                "Today",
+                "LastMonth",
+                "ThisMonth",
+                "All"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/SyncPeriod"
+                }
+              ]
             }
           }
         ],
@@ -140,7 +160,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SyncNotificationsCommand"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SyncNotificationsCommand"
+                  }
+                ]
               }
             }
           },
@@ -164,7 +188,17 @@
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SyncPeriod"
+              "enum": [
+                "Today",
+                "LastMonth",
+                "ThisMonth",
+                "All"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/SyncPeriod"
+                }
+              ]
             }
           }
         ],
@@ -182,7 +216,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SyncClearanceRequestsCommand"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SyncClearanceRequestsCommand"
+                  }
+                ]
               }
             }
           },
@@ -206,7 +244,17 @@
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SyncPeriod"
+              "enum": [
+                "Today",
+                "LastMonth",
+                "ThisMonth",
+                "All"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/SyncPeriod"
+                }
+              ]
             }
           }
         ],
@@ -224,7 +272,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SyncGmrsCommand"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SyncGmrsCommand"
+                  }
+                ]
               }
             }
           },
@@ -246,7 +298,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SyncDecisionsCommand"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SyncDecisionsCommand"
+                  }
+                ]
               }
             }
           },
@@ -345,7 +401,13 @@
         "type": "object",
         "properties": {
           "documentType": {
-            "$ref": "#/components/schemas/AccompanyingDocumentDocumentTypeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AccompanyingDocumentDocumentTypeEnum"
+              }
+            ],
+            "description": "Additional document type",
+            "nullable": true
           },
           "documentReference": {
             "type": "string",
@@ -384,7 +446,13 @@
             "nullable": true
           },
           "externalReference": {
-            "$ref": "#/components/schemas/ExternalReference"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalReference"
+              }
+            ],
+            "description": "External reference of accompanying document, which relates to a downstream service",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -424,8 +492,7 @@
           "PackingList",
           "RoadConsignmentNote"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "Address": {
         "type": "object",
@@ -491,7 +558,13 @@
             "nullable": true
           },
           "internationalTelephone": {
-            "$ref": "#/components/schemas/InternationalTelephone"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InternationalTelephone"
+              }
+            ],
+            "description": "International phone number",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -530,7 +603,13 @@
             "nullable": true
           },
           "analysisType": {
-            "$ref": "#/components/schemas/ApplicantAnalysisTypeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicantAnalysisTypeEnum"
+              }
+            ],
+            "description": "Type of analysis",
+            "nullable": true
           },
           "numberOfSamples": {
             "type": "integer",
@@ -544,10 +623,22 @@
             "nullable": true
           },
           "conservationOfSample": {
-            "$ref": "#/components/schemas/ApplicantConservationOfSampleEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApplicantConservationOfSampleEnum"
+              }
+            ],
+            "description": "Conservation of sample",
+            "nullable": true
           },
           "inspector": {
-            "$ref": "#/components/schemas/Inspector"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Inspector"
+              }
+            ],
+            "description": "inspector",
+            "nullable": true
           },
           "sampledOn": {
             "type": "string",
@@ -564,8 +655,7 @@
           "CounterAnalysis",
           "SecondExpertAnalysis"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "ApplicantConservationOfSampleEnum": {
         "enum": [
@@ -573,8 +663,7 @@
           "Chilled",
           "Frozen"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "ApprovedEstablishment": {
         "type": "object",
@@ -694,7 +783,13 @@
             "nullable": true
           },
           "postalAddress": {
-            "$ref": "#/components/schemas/PostalAddress"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PostalAddress"
+              }
+            ],
+            "description": "Billing postal address",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -780,10 +875,22 @@
         "type": "object",
         "properties": {
           "reason": {
-            "$ref": "#/components/schemas/ChedppNotAcceptableReasonReasonEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChedppNotAcceptableReasonReasonEnum"
+              }
+            ],
+            "description": "reason for refusal",
+            "nullable": true
           },
           "commodityOrPackage": {
-            "$ref": "#/components/schemas/ChedppNotAcceptableReasonCommodityOrPackageEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChedppNotAcceptableReasonCommodityOrPackageEnum"
+              }
+            ],
+            "description": "commodity or package",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -794,8 +901,7 @@
           "P",
           "Cp"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "ChedppNotAcceptableReasonReasonEnum": {
         "enum": [
@@ -829,8 +935,7 @@
           "OthCnl",
           "OthO"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "Commodities": {
         "type": "object",
@@ -921,7 +1026,13 @@
             "nullable": true
           },
           "commodityIntendedFor": {
-            "$ref": "#/components/schemas/CommoditiesCommodityIntendedForEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommoditiesCommodityIntendedForEnum"
+              }
+            ],
+            "description": "What the commodity is intended for",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -933,8 +1044,7 @@
           "Further",
           "Other"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "CommodityComplement": {
         "type": "object",
@@ -1037,7 +1147,13 @@
             "nullable": true
           },
           "riskAssesment": {
-            "$ref": "#/components/schemas/CommodityRiskResult"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResult"
+              }
+            ],
+            "description": "",
+            "nullable": true
           },
           "checks": {
             "type": "array",
@@ -1054,22 +1170,58 @@
         "type": "object",
         "properties": {
           "riskDecision": {
-            "$ref": "#/components/schemas/CommodityRiskResultRiskDecisionEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResultRiskDecisionEnum"
+              }
+            ],
+            "description": "CHED-A, CHED-D, CHED-P - what is the commodity complement risk decision",
+            "nullable": true
           },
           "exitRiskDecision": {
-            "$ref": "#/components/schemas/CommodityRiskResultExitRiskDecisionEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResultExitRiskDecisionEnum"
+              }
+            ],
+            "description": "Transit CHED - what is the commodity complement exit risk decision",
+            "nullable": true
           },
           "hmiDecision": {
-            "$ref": "#/components/schemas/CommodityRiskResultHmiDecisionEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResultHmiDecisionEnum"
+              }
+            ],
+            "description": "HMI decision required",
+            "nullable": true
           },
           "phsiDecision": {
-            "$ref": "#/components/schemas/CommodityRiskResultPhsiDecisionEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResultPhsiDecisionEnum"
+              }
+            ],
+            "description": "PHSI decision required",
+            "nullable": true
           },
           "phsiClassification": {
-            "$ref": "#/components/schemas/CommodityRiskResultPhsiClassificationEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommodityRiskResultPhsiClassificationEnum"
+              }
+            ],
+            "description": "PHSI classification",
+            "nullable": true
           },
           "phsi": {
-            "$ref": "#/components/schemas/Phsi"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Phsi"
+              }
+            ],
+            "description": "PHSI Decision Breakdown",
+            "nullable": true
           },
           "uniqueId": {
             "type": "string",
@@ -1115,16 +1267,14 @@
           "Notrequired",
           "Inconclusive"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "CommodityRiskResultHmiDecisionEnum": {
         "enum": [
           "Required",
           "Notrequired"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "CommodityRiskResultPhsiClassificationEnum": {
         "enum": [
@@ -1132,16 +1282,14 @@
           "Reduced",
           "Controlled"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "CommodityRiskResultPhsiDecisionEnum": {
         "enum": [
           "Required",
           "Notrequired"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "CommodityRiskResultRiskDecisionEnum": {
         "enum": [
@@ -1150,8 +1298,7 @@
           "Inconclusive",
           "ReenforcedCheck"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "CommonUserCharge": {
         "type": "object",
@@ -1237,7 +1384,13 @@
             "nullable": true
           },
           "identityCheckType": {
-            "$ref": "#/components/schemas/ConsignmentCheckIdentityCheckTypeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConsignmentCheckIdentityCheckTypeEnum"
+              }
+            ],
+            "description": "Type of identity check performed",
+            "nullable": true
           },
           "identityCheckResult": {
             "type": "string",
@@ -1245,7 +1398,13 @@
             "nullable": true
           },
           "identityCheckNotDoneReason": {
-            "$ref": "#/components/schemas/ConsignmentCheckIdentityCheckNotDoneReasonEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConsignmentCheckIdentityCheckNotDoneReasonEnum"
+              }
+            ],
+            "description": "What was the reason for skipping identity check",
+            "nullable": true
           },
           "physicalCheckDone": {
             "type": "boolean",
@@ -1258,7 +1417,13 @@
             "nullable": true
           },
           "physicalCheckNotDoneReason": {
-            "$ref": "#/components/schemas/ConsignmentCheckPhysicalCheckNotDoneReasonEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConsignmentCheckPhysicalCheckNotDoneReasonEnum"
+              }
+            ],
+            "description": "What was the reason for skipping physical check",
+            "nullable": true
           },
           "physicalCheckOtherText": {
             "type": "string",
@@ -1294,8 +1459,7 @@
           "ReducedChecksRegime",
           "NotRequired"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "ConsignmentCheckIdentityCheckTypeEnum": {
         "enum": [
@@ -1303,16 +1467,14 @@
           "FullIdentityCheck",
           "NotDone"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "ConsignmentCheckPhysicalCheckNotDoneReasonEnum": {
         "enum": [
           "ReducedChecksRegime",
           "Other"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "ContactDetails": {
         "type": "object",
@@ -1344,16 +1506,40 @@
         "type": "object",
         "properties": {
           "feedbackInformation": {
-            "$ref": "#/components/schemas/FeedbackInformation"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FeedbackInformation"
+              }
+            ],
+            "description": "Feedback information of Control",
+            "nullable": true
           },
           "detailsOnReExport": {
-            "$ref": "#/components/schemas/DetailsOnReExport"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DetailsOnReExport"
+              }
+            ],
+            "description": "Details on re-export",
+            "nullable": true
           },
           "officialInspector": {
-            "$ref": "#/components/schemas/OfficialInspector"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OfficialInspector"
+              }
+            ],
+            "description": "Official inspector",
+            "nullable": true
           },
           "consignmentLeave": {
-            "$ref": "#/components/schemas/ControlConsignmentLeaveEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ControlConsignmentLeaveEnum"
+              }
+            ],
+            "description": "Is the consignment leaving UK borders?",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -1362,7 +1548,13 @@
         "type": "object",
         "properties": {
           "officialVeterinarian": {
-            "$ref": "#/components/schemas/OfficialVeterinarian"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OfficialVeterinarian"
+              }
+            ],
+            "description": "Official veterinarian",
+            "nullable": true
           },
           "customsReferenceNo": {
             "type": "string",
@@ -1390,7 +1582,13 @@
             "nullable": true
           },
           "iuuOption": {
-            "$ref": "#/components/schemas/ControlAuthorityIuuOptionEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ControlAuthorityIuuOptionEnum"
+              }
+            ],
+            "description": "Result of Illegal, Unreported and Unregulated (IUU) check",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -1401,8 +1599,7 @@
           "Iuuna",
           "IUUNotCompliant"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "ControlConsignmentLeaveEnum": {
         "enum": [
@@ -1410,8 +1607,7 @@
           "No",
           "ItHasBeenDestroyed"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "Decision": {
         "type": "object",
@@ -1422,28 +1618,76 @@
             "nullable": true
           },
           "notAcceptableAction": {
-            "$ref": "#/components/schemas/DecisionNotAcceptableActionEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionEnum"
+              }
+            ],
+            "description": "Filled if consignmentAcceptable is set to false",
+            "nullable": true
           },
           "notAcceptableActionDestructionReason": {
-            "$ref": "#/components/schemas/DecisionNotAcceptableActionDestructionReasonEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionDestructionReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to destruction",
+            "nullable": true
           },
           "notAcceptableActionEntryRefusalReason": {
-            "$ref": "#/components/schemas/DecisionNotAcceptableActionEntryRefusalReasonEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionEntryRefusalReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to entry refusal",
+            "nullable": true
           },
           "notAcceptableActionQuarantineImposedReason": {
-            "$ref": "#/components/schemas/DecisionNotAcceptableActionQuarantineImposedReasonEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionQuarantineImposedReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to quarantine imposed",
+            "nullable": true
           },
           "notAcceptableActionSpecialTreatmentReason": {
-            "$ref": "#/components/schemas/DecisionNotAcceptableActionSpecialTreatmentReasonEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionSpecialTreatmentReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to special treatment",
+            "nullable": true
           },
           "notAcceptableActionIndustrialProcessingReason": {
-            "$ref": "#/components/schemas/DecisionNotAcceptableActionIndustrialProcessingReasonEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionIndustrialProcessingReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to industrial processing",
+            "nullable": true
           },
           "notAcceptableActionReDispatchReason": {
-            "$ref": "#/components/schemas/DecisionNotAcceptableActionReDispatchReasonEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionReDispatchReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to re-dispatch",
+            "nullable": true
           },
           "notAcceptableActionUseForOtherPurposesReason": {
-            "$ref": "#/components/schemas/DecisionNotAcceptableActionUseForOtherPurposesReasonEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionNotAcceptableActionUseForOtherPurposesReasonEnum"
+              }
+            ],
+            "description": "Filled if not acceptable action is set to use for other purposes",
+            "nullable": true
           },
           "notAcceptableDestructionReason": {
             "type": "string",
@@ -1493,10 +1737,22 @@
             "nullable": true
           },
           "detailsOfControlledDestinations": {
-            "$ref": "#/components/schemas/Party"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Party"
+              }
+            ],
+            "description": "Details of controlled destinations",
+            "nullable": true
           },
           "specificWarehouseNonConformingConsignment": {
-            "$ref": "#/components/schemas/DecisionSpecificWarehouseNonConformingConsignmentEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionSpecificWarehouseNonConformingConsignmentEnum"
+              }
+            ],
+            "description": "Filled if consignment is set to acceptable and decision type is Specific Warehouse",
+            "nullable": true
           },
           "temporaryDeadline": {
             "type": "string",
@@ -1504,16 +1760,40 @@
             "nullable": true
           },
           "decisionEnum": {
-            "$ref": "#/components/schemas/DecisionDecisionEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionDecisionEnum"
+              }
+            ],
+            "description": "Detailed decision for consignment",
+            "nullable": true
           },
           "freeCirculationPurpose": {
-            "$ref": "#/components/schemas/DecisionFreeCirculationPurposeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionFreeCirculationPurposeEnum"
+              }
+            ],
+            "description": "Decision over purpose of free circulation in country",
+            "nullable": true
           },
           "definitiveImportPurpose": {
-            "$ref": "#/components/schemas/DecisionDefinitiveImportPurposeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionDefinitiveImportPurposeEnum"
+              }
+            ],
+            "description": "Decision over purpose of definitive import",
+            "nullable": true
           },
           "ifChanneledOption": {
-            "$ref": "#/components/schemas/DecisionIfChanneledOptionEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DecisionIfChanneledOptionEnum"
+              }
+            ],
+            "description": "Decision channeled option based on (article8, article15)",
+            "nullable": true
           },
           "customWarehouseRegisteredNumber": {
             "type": "string",
@@ -1596,8 +1876,7 @@
           "AcceptableForTransfer",
           "HorseReEntry"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionDefinitiveImportPurposeEnum": {
         "enum": [
@@ -1605,8 +1884,7 @@
           "Approvedbodies",
           "Quarantine"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionFreeCirculationPurposeEnum": {
         "enum": [
@@ -1617,16 +1895,14 @@
           "FurtherProcess",
           "Other"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionIfChanneledOptionEnum": {
         "enum": [
           "Article8",
           "Article15"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionNotAcceptableActionDestructionReasonEnum": {
         "enum": [
@@ -1635,8 +1911,7 @@
           "PackagingMaterial",
           "Other"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionNotAcceptableActionEntryRefusalReasonEnum": {
         "enum": [
@@ -1646,8 +1921,7 @@
           "MeansOfTransport",
           "Other"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionNotAcceptableActionEnum": {
         "enum": [
@@ -1665,8 +1939,7 @@
           "ReDispatch",
           "UseForOtherPurposes"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionNotAcceptableActionIndustrialProcessingReasonEnum": {
         "enum": [
@@ -1675,8 +1948,7 @@
           "PackagingMaterial",
           "Other"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionNotAcceptableActionQuarantineImposedReasonEnum": {
         "enum": [
@@ -1685,8 +1957,7 @@
           "PackagingMaterial",
           "Other"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionNotAcceptableActionReDispatchReasonEnum": {
         "enum": [
@@ -1696,8 +1967,7 @@
           "MeansOfTransport",
           "Other"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionNotAcceptableActionSpecialTreatmentReasonEnum": {
         "enum": [
@@ -1706,8 +1976,7 @@
           "PackagingMaterial",
           "Other"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionNotAcceptableActionUseForOtherPurposesReasonEnum": {
         "enum": [
@@ -1717,8 +1986,7 @@
           "MeansOfTransport",
           "Other"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DecisionSpecificWarehouseNonConformingConsignmentEnum": {
         "enum": [
@@ -1727,8 +1995,7 @@
           "ShipSupplier",
           "Ship"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "DetailsOnReExport": {
         "type": "object",
@@ -1745,7 +2012,13 @@
             "nullable": true
           },
           "transportType": {
-            "$ref": "#/components/schemas/DetailsOnReExportTransportTypeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DetailsOnReExportTransportTypeEnum"
+              }
+            ],
+            "description": "Type of transport to be used",
+            "nullable": true
           },
           "document": {
             "type": "string",
@@ -1775,8 +2048,7 @@
           "CShipRoad",
           "CShipRail"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "EconomicOperator": {
         "type": "object",
@@ -1787,10 +2059,22 @@
             "nullable": true
           },
           "type": {
-            "$ref": "#/components/schemas/EconomicOperatorTypeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperatorTypeEnum"
+              }
+            ],
+            "description": "Type of organisation",
+            "nullable": true
           },
           "status": {
-            "$ref": "#/components/schemas/EconomicOperatorStatusEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperatorStatusEnum"
+              }
+            ],
+            "description": "Status of organisation",
+            "nullable": true
           },
           "companyName": {
             "type": "string",
@@ -1803,7 +2087,13 @@
             "nullable": true
           },
           "address": {
-            "$ref": "#/components/schemas/Address"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Address"
+              }
+            ],
+            "description": "Address of economic operator",
+            "nullable": true
           },
           "approvalNumber": {
             "type": "string",
@@ -1830,8 +2120,7 @@
           "Nonapproved",
           "Suspended"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "EconomicOperatorTypeEnum": {
         "enum": [
@@ -1849,14 +2138,19 @@
           "Packer",
           "Pod"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "ExternalReference": {
         "type": "object",
         "properties": {
           "system": {
-            "$ref": "#/components/schemas/ExternalReferenceSystemEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalReferenceSystemEnum"
+              }
+            ],
+            "description": "Identifier of the external system to which the reference relates",
+            "nullable": true
           },
           "reference": {
             "type": "string",
@@ -1888,14 +2182,19 @@
           "Enotification",
           "Ncts"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "FeedbackInformation": {
         "type": "object",
         "properties": {
           "authorityType": {
-            "$ref": "#/components/schemas/FeedbackInformationAuthorityTypeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FeedbackInformationAuthorityTypeEnum"
+              }
+            ],
+            "description": "Type of authority",
+            "nullable": true
           },
           "consignmentArrival": {
             "type": "boolean",
@@ -1927,8 +2226,7 @@
           "Localvetunit",
           "Inspunit"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "IdentificationDetails": {
         "type": "object",
@@ -1969,7 +2267,13 @@
             "nullable": true
           },
           "permanentAddress": {
-            "$ref": "#/components/schemas/EconomicOperator"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Permanent address of the species",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -2036,10 +2340,20 @@
             "nullable": true
           },
           "relationships": {
-            "$ref": "#/components/schemas/NotificationTdmRelationships"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NotificationTdmRelationships"
+              }
+            ],
+            "nullable": true
           },
           "commoditiesSummary": {
-            "$ref": "#/components/schemas/Commodities"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Commodities"
+              }
+            ],
+            "nullable": true
           },
           "commodities": {
             "type": "array",
@@ -2101,10 +2415,22 @@
             "nullable": true
           },
           "lastUpdatedBy": {
-            "$ref": "#/components/schemas/UserInformation"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserInformation"
+              }
+            ],
+            "description": "User entity whose update was last",
+            "nullable": true
           },
           "importNotificationType": {
-            "$ref": "#/components/schemas/ImportNotificationTypeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImportNotificationTypeEnum"
+              }
+            ],
+            "description": "The Type of notification that has been submitted",
+            "nullable": true
           },
           "replaces": {
             "type": "string",
@@ -2117,10 +2443,22 @@
             "nullable": true
           },
           "status": {
-            "$ref": "#/components/schemas/ImportNotificationStatusEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImportNotificationStatusEnum"
+              }
+            ],
+            "description": "Current status of the notification. When created by an importer, the notification has the status 'SUBMITTED'. Before submission of the notification it has the status 'DRAFT'. When the BIP starts validation of the notification it has the status 'IN PROGRESS' Once the BIP validates the notification, it gets the status 'VALIDATED'. 'AMEND' is set when the Part-1 user is modifying the notification. 'MODIFY' is set when Part-2 user is modifying the notification. Replaced - When the notification is replaced by another notification. Rejected - Notification moves to Rejected status when rejected by a Part-2 user. ",
+            "nullable": true
           },
           "splitConsignment": {
-            "$ref": "#/components/schemas/SplitConsignment"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SplitConsignment"
+              }
+            ],
+            "description": "Present if the consignment has been split",
+            "nullable": true
           },
           "childNotification": {
             "type": "boolean",
@@ -2128,10 +2466,22 @@
             "nullable": true
           },
           "riskAssessment": {
-            "$ref": "#/components/schemas/RiskAssessmentResult"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskAssessmentResult"
+              }
+            ],
+            "description": "Result of risk assessment by the risk scorer",
+            "nullable": true
           },
           "journeyRiskCategorisation": {
-            "$ref": "#/components/schemas/JourneyRiskCategorisationResult"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JourneyRiskCategorisationResult"
+              }
+            ],
+            "description": "Details of the risk categorisation level for a notification",
+            "nullable": true
           },
           "isHighRiskEuImport": {
             "type": "boolean",
@@ -2139,10 +2489,22 @@
             "nullable": true
           },
           "partOne": {
-            "$ref": "#/components/schemas/PartOne"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartOne"
+              }
+            ],
+            "description": "",
+            "nullable": true
           },
           "decisionBy": {
-            "$ref": "#/components/schemas/UserInformation"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserInformation"
+              }
+            ],
+            "description": "Information about the user who set the decision in Part 2",
+            "nullable": true
           },
           "decisionDate": {
             "type": "string",
@@ -2150,10 +2512,22 @@
             "nullable": true
           },
           "partTwo": {
-            "$ref": "#/components/schemas/PartTwo"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartTwo"
+              }
+            ],
+            "description": "Part of the notification which contains information filled by inspector at BIP/DPE",
+            "nullable": true
           },
           "partThree": {
-            "$ref": "#/components/schemas/PartThree"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartThree"
+              }
+            ],
+            "description": "Part of the notification which contains information filled by LVU if control of consignment is needed.",
+            "nullable": true
           },
           "officialVeterinarian": {
             "type": "string",
@@ -2228,8 +2602,7 @@
           "PartiallyRejected",
           "SplitConsignment"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "ImportNotificationTypeEnum": {
         "enum": [
@@ -2239,17 +2612,28 @@
           "Ced",
           "Imp"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "InspectionCheck": {
         "type": "object",
         "properties": {
           "type": {
-            "$ref": "#/components/schemas/InspectionCheckTypeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InspectionCheckTypeEnum"
+              }
+            ],
+            "description": "Type of check",
+            "nullable": true
           },
           "status": {
-            "$ref": "#/components/schemas/InspectionCheckStatusEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InspectionCheckStatusEnum"
+              }
+            ],
+            "description": "Status of the check",
+            "nullable": true
           },
           "reason": {
             "type": "string",
@@ -2284,8 +2668,7 @@
           "ToBeInspected",
           "Hold"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "InspectionCheckTypeEnum": {
         "enum": [
@@ -2294,8 +2677,7 @@
           "PhsiPhysical",
           "Hmi"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "InspectionOverride": {
         "type": "object",
@@ -2312,7 +2694,13 @@
             "nullable": true
           },
           "overriddenBy": {
-            "$ref": "#/components/schemas/UserInformation"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserInformation"
+              }
+            ],
+            "description": "User entity who has manually overridden the inspection",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -2358,10 +2746,22 @@
         "type": "object",
         "properties": {
           "riskLevel": {
-            "$ref": "#/components/schemas/JourneyRiskCategorisationResultRiskLevelEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JourneyRiskCategorisationResultRiskLevelEnum"
+              }
+            ],
+            "description": "Risk Level is defined using enum values High,Medium,Low",
+            "nullable": true
           },
           "riskLevelMethod": {
-            "$ref": "#/components/schemas/JourneyRiskCategorisationResultRiskLevelMethodEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JourneyRiskCategorisationResultRiskLevelMethodEnum"
+              }
+            ],
+            "description": "Indicator of whether the risk level was determined by the system or by the user",
+            "nullable": true
           },
           "riskLevelSetFor": {
             "type": "string",
@@ -2378,16 +2778,14 @@
           "Medium",
           "Low"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "JourneyRiskCategorisationResultRiskLevelMethodEnum": {
         "enum": [
           "System",
           "User"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "LaboratoryTestResult": {
         "type": "object",
@@ -2414,7 +2812,13 @@
             "nullable": true
           },
           "conclusion": {
-            "$ref": "#/components/schemas/LaboratoryTestResultConclusionEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LaboratoryTestResultConclusionEnum"
+              }
+            ],
+            "description": "Conclusion of laboratory test",
+            "nullable": true
           },
           "labTestCreatedOn": {
             "type": "string",
@@ -2432,8 +2836,7 @@
           "NotInterpretable",
           "Pending"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "LaboratoryTests": {
         "type": "object",
@@ -2445,7 +2848,13 @@
             "nullable": true
           },
           "testReason": {
-            "$ref": "#/components/schemas/LaboratoryTestsTestReasonEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LaboratoryTestsTestReasonEnum"
+              }
+            ],
+            "description": "Reason for test",
+            "nullable": true
           },
           "singleLaboratoryTests": {
             "type": "array",
@@ -2467,14 +2876,19 @@
           "Required",
           "LatentInfectionSampling"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "MeansOfTransport": {
         "type": "object",
         "properties": {
           "type": {
-            "$ref": "#/components/schemas/MeansOfTransportTypeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MeansOfTransportTypeEnum"
+              }
+            ],
+            "description": "Type of transport",
+            "nullable": true
           },
           "document": {
             "type": "string",
@@ -2500,8 +2914,7 @@
           "ShipRailwayWagon",
           "ShipRoadVehicle"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "NominatedContact": {
         "type": "object",
@@ -2528,7 +2941,12 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/ImportNotification"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImportNotification"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -2537,7 +2955,12 @@
         "type": "object",
         "properties": {
           "movements": {
-            "$ref": "#/components/schemas/TdmRelationshipObject"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TdmRelationshipObject"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -2571,7 +2994,13 @@
             "nullable": true
           },
           "address": {
-            "$ref": "#/components/schemas/Address"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Address"
+              }
+            ],
+            "description": "Address of inspector",
+            "nullable": true
           },
           "signed": {
             "type": "string",
@@ -2621,10 +3050,22 @@
         "type": "object",
         "properties": {
           "typeOfImp": {
-            "$ref": "#/components/schemas/PartOneTypeOfImpEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartOneTypeOfImpEnum"
+              }
+            ],
+            "description": "Used to indicate what type of EU Import the notification is - Live Animals, Product Of Animal Origin or High Risk Food Not Of Animal Origin",
+            "nullable": true
           },
           "personResponsible": {
-            "$ref": "#/components/schemas/Party"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Party"
+              }
+            ],
+            "description": "The individual who has submitted the notification",
+            "nullable": true
           },
           "customsReferenceNumber": {
             "type": "string",
@@ -2642,28 +3083,76 @@
             "nullable": true
           },
           "consignor": {
-            "$ref": "#/components/schemas/EconomicOperator"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Person or Company that sends shipment",
+            "nullable": true
           },
           "consignorTwo": {
-            "$ref": "#/components/schemas/EconomicOperator"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Person or Company that sends shipment",
+            "nullable": true
           },
           "packer": {
-            "$ref": "#/components/schemas/EconomicOperator"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Person or Company that packs the shipment",
+            "nullable": true
           },
           "consignee": {
-            "$ref": "#/components/schemas/EconomicOperator"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Person or Company that receives shipment",
+            "nullable": true
           },
           "importer": {
-            "$ref": "#/components/schemas/EconomicOperator"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Person or Company that is importing the consignment",
+            "nullable": true
           },
           "placeOfDestination": {
-            "$ref": "#/components/schemas/EconomicOperator"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Where the shipment is to be sent? For IMP minimum 48 hour accommodation/holding location.",
+            "nullable": true
           },
           "pod": {
-            "$ref": "#/components/schemas/EconomicOperator"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "A temporary place of destination for plants",
+            "nullable": true
           },
           "placeOfOriginHarvest": {
-            "$ref": "#/components/schemas/EconomicOperator"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Place in which the animals or products originate",
+            "nullable": true
           },
           "additionalPermanentAddresses": {
             "type": "array",
@@ -2699,7 +3188,13 @@
             "nullable": true
           },
           "purpose": {
-            "$ref": "#/components/schemas/Purpose"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Purpose"
+              }
+            ],
+            "description": "Purpose of consignment details",
+            "nullable": true
           },
           "pointOfEntry": {
             "type": "string",
@@ -2712,10 +3207,22 @@
             "nullable": true
           },
           "meansOfTransport": {
-            "$ref": "#/components/schemas/MeansOfTransport"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MeansOfTransport"
+              }
+            ],
+            "description": "How consignment is transported after BIP",
+            "nullable": true
           },
           "transporter": {
-            "$ref": "#/components/schemas/EconomicOperator"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Transporter of consignment details",
+            "nullable": true
           },
           "transporterDetailsRequired": {
             "type": "boolean",
@@ -2723,7 +3230,13 @@
             "nullable": true
           },
           "meansOfTransportFromEntryPoint": {
-            "$ref": "#/components/schemas/MeansOfTransport"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MeansOfTransport"
+              }
+            ],
+            "description": "Transport to BIP",
+            "nullable": true
           },
           "estimatedJourneyTimeInMinutes": {
             "type": "number",
@@ -2737,7 +3250,13 @@
             "nullable": true
           },
           "veterinaryInformation": {
-            "$ref": "#/components/schemas/VeterinaryInformation"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VeterinaryInformation"
+              }
+            ],
+            "description": "Part 1 - Holds the information related to veterinary checks and details",
+            "nullable": true
           },
           "importerLocalReferenceNumber": {
             "type": "string",
@@ -2745,7 +3264,13 @@
             "nullable": true
           },
           "route": {
-            "$ref": "#/components/schemas/Route"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Route"
+              }
+            ],
+            "description": "Contains countries and transfer points that consignment is going through",
+            "nullable": true
           },
           "sealsContainers": {
             "type": "array",
@@ -2762,7 +3287,13 @@
             "nullable": true
           },
           "submittedBy": {
-            "$ref": "#/components/schemas/UserInformation"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserInformation"
+              }
+            ],
+            "description": "Information about user who submitted notification",
+            "nullable": true
           },
           "consignmentValidations": {
             "type": "array",
@@ -2794,7 +3325,13 @@
             "nullable": true
           },
           "contactDetails": {
-            "$ref": "#/components/schemas/ContactDetails"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContactDetails"
+              }
+            ],
+            "description": "Person to be contacted if there is an issue with the consignment",
+            "nullable": true
           },
           "nominatedContacts": {
             "type": "array",
@@ -2811,7 +3348,13 @@
             "nullable": true
           },
           "billingInformation": {
-            "$ref": "#/components/schemas/BillingInformation"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BillingInformation"
+              }
+            ],
+            "description": "",
+            "nullable": true
           },
           "isChargeable": {
             "type": "boolean",
@@ -2824,10 +3367,22 @@
             "nullable": true
           },
           "commonUserCharge": {
-            "$ref": "#/components/schemas/CommonUserCharge"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommonUserCharge"
+              }
+            ],
+            "description": "",
+            "nullable": true
           },
           "provideCtcMrn": {
-            "$ref": "#/components/schemas/PartOneProvideCtcMrnEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartOneProvideCtcMrnEnum"
+              }
+            ],
+            "description": "When the NCTS MRN will be added for the Common Transit Convention (CTC)",
+            "nullable": true
           },
           "arrivesAt": {
             "type": "string",
@@ -2850,8 +3405,7 @@
           "YesAddLater",
           "No"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "PartOneTypeOfImpEnum": {
         "enum": [
@@ -2859,17 +3413,28 @@
           "P",
           "D"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "PartThree": {
         "type": "object",
         "properties": {
           "controlStatus": {
-            "$ref": "#/components/schemas/PartThreeControlStatusEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartThreeControlStatusEnum"
+              }
+            ],
+            "description": "Control status enum",
+            "nullable": true
           },
           "control": {
-            "$ref": "#/components/schemas/Control"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Control"
+              }
+            ],
+            "description": "Control details",
+            "nullable": true
           },
           "consignmentValidations": {
             "type": "array",
@@ -2885,10 +3450,22 @@
             "nullable": true
           },
           "sealCheck": {
-            "$ref": "#/components/schemas/SealCheck"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SealCheck"
+              }
+            ],
+            "description": "Seal check details",
+            "nullable": true
           },
           "sealCheckOverride": {
-            "$ref": "#/components/schemas/InspectionOverride"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InspectionOverride"
+              }
+            ],
+            "description": "Seal check override details",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -2898,20 +3475,37 @@
           "Required",
           "Completed"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "PartTwo": {
         "type": "object",
         "properties": {
           "decision": {
-            "$ref": "#/components/schemas/Decision"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Decision"
+              }
+            ],
+            "description": "Decision on the consignment",
+            "nullable": true
           },
           "consignmentCheck": {
-            "$ref": "#/components/schemas/ConsignmentCheck"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConsignmentCheck"
+              }
+            ],
+            "description": "Consignment check",
+            "nullable": true
           },
           "impactOfTransportOnAnimals": {
-            "$ref": "#/components/schemas/ImpactOfTransportOnAnimals"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImpactOfTransportOnAnimals"
+              }
+            ],
+            "description": "Checks of impact of transport on animals",
+            "nullable": true
           },
           "laboratoryTestsRequired": {
             "type": "boolean",
@@ -2919,7 +3513,13 @@
             "nullable": true
           },
           "laboratoryTests": {
-            "$ref": "#/components/schemas/LaboratoryTests"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LaboratoryTests"
+              }
+            ],
+            "description": "Laboratory tests information details",
+            "nullable": true
           },
           "resealedContainersIncluded": {
             "type": "boolean",
@@ -2943,10 +3543,22 @@
             "nullable": true
           },
           "controlAuthority": {
-            "$ref": "#/components/schemas/ControlAuthority"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ControlAuthority"
+              }
+            ],
+            "description": "Control Authority information details",
+            "nullable": true
           },
           "controlledDestination": {
-            "$ref": "#/components/schemas/EconomicOperator"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EconomicOperator"
+              }
+            ],
+            "description": "Controlled destination",
+            "nullable": true
           },
           "bipLocalReferenceNumber": {
             "type": "string",
@@ -3001,7 +3613,13 @@
             "nullable": true
           },
           "inspectionOverride": {
-            "$ref": "#/components/schemas/InspectionOverride"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InspectionOverride"
+              }
+            ],
+            "description": "Details about the manual inspection override",
+            "nullable": true
           },
           "autoClearedOn": {
             "type": "string",
@@ -3075,7 +3693,13 @@
             "nullable": true
           },
           "type": {
-            "$ref": "#/components/schemas/PartyTypeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartyTypeEnum"
+              }
+            ],
+            "description": "Type of party",
+            "nullable": true
           },
           "approvalNumber": {
             "type": "string",
@@ -3105,8 +3729,7 @@
           "CommercialTransporter",
           "PrivateTransporter"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "Phsi": {
         "type": "object",
@@ -3179,7 +3802,13 @@
             "nullable": true
           },
           "internalMarketPurpose": {
-            "$ref": "#/components/schemas/PurposeInternalMarketPurposeEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PurposeInternalMarketPurposeEnum"
+              }
+            ],
+            "description": "Detailed purpose of internal market purpose group",
+            "nullable": true
           },
           "thirdCountryTranshipment": {
             "type": "string",
@@ -3187,7 +3816,13 @@
             "nullable": true
           },
           "forNonConforming": {
-            "$ref": "#/components/schemas/PurposeForNonConformingEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PurposeForNonConformingEnum"
+              }
+            ],
+            "description": "Detailed purpose for non conforming purpose group",
+            "nullable": true
           },
           "regNumber": {
             "type": "string",
@@ -3223,7 +3858,13 @@
             "nullable": true
           },
           "forImportOrAdmission": {
-            "$ref": "#/components/schemas/PurposeForImportOrAdmissionEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PurposeForImportOrAdmissionEnum"
+              }
+            ],
+            "description": "Specification of Import or admission purpose",
+            "nullable": true
           },
           "exitDate": {
             "type": "string",
@@ -3237,7 +3878,13 @@
             "nullable": true
           },
           "purposeGroup": {
-            "$ref": "#/components/schemas/PurposePurposeGroupEnum"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PurposePurposeGroupEnum"
+              }
+            ],
+            "description": "Purpose group of consignment (general purpose)",
+            "nullable": true
           },
           "estimatedArrivesAtPortOfExit": {
             "type": "string",
@@ -3254,8 +3901,7 @@
           "HorsesReEntry",
           "TemporaryAdmissionHorses"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "PurposeForNonConformingEnum": {
         "enum": [
@@ -3264,8 +3910,7 @@
           "ShipSupplier",
           "Ship"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "PurposeInternalMarketPurposeEnum": {
         "enum": [
@@ -3288,8 +3933,7 @@
           "GameRestocking",
           "RegisteredHorses"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "PurposePurposeGroupEnum": {
         "enum": [
@@ -3303,8 +3947,7 @@
           "ForImportReConformityCheck",
           "ForImportNonInternalMarket"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "RelationshipDataItem": {
         "type": "object",
@@ -3322,7 +3965,12 @@
             "nullable": true
           },
           "links": {
-            "$ref": "#/components/schemas/ResourceLink"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLink"
+              }
+            ],
+            "nullable": true
           },
           "sourceItem": {
             "type": "integer",
@@ -3414,7 +4062,13 @@
             "nullable": true
           },
           "officialInspector": {
-            "$ref": "#/components/schemas/OfficialInspector"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OfficialInspector"
+              }
+            ],
+            "description": "Official inspector",
+            "nullable": true
           },
           "checkedOn": {
             "type": "string",
@@ -3477,10 +4131,22 @@
             "nullable": true
           },
           "applicant": {
-            "$ref": "#/components/schemas/Applicant"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Applicant"
+              }
+            ],
+            "description": "Laboratory tests information details and information about laboratory",
+            "nullable": true
           },
           "laboratoryTestResult": {
-            "$ref": "#/components/schemas/LaboratoryTestResult"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LaboratoryTestResult"
+              }
+            ],
+            "description": "Information about results of test",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -3505,7 +4171,17 @@
         "type": "object",
         "properties": {
           "syncPeriod": {
-            "$ref": "#/components/schemas/SyncPeriod"
+            "enum": [
+              "Today",
+              "LastMonth",
+              "ThisMonth",
+              "All"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SyncPeriod"
+              }
+            ]
           },
           "rootFolder": {
             "type": "string",
@@ -3537,7 +4213,17 @@
         "type": "object",
         "properties": {
           "syncPeriod": {
-            "$ref": "#/components/schemas/SyncPeriod"
+            "enum": [
+              "Today",
+              "LastMonth",
+              "ThisMonth",
+              "All"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SyncPeriod"
+              }
+            ]
           },
           "rootFolder": {
             "type": "string",
@@ -3569,7 +4255,17 @@
         "type": "object",
         "properties": {
           "syncPeriod": {
-            "$ref": "#/components/schemas/SyncPeriod"
+            "enum": [
+              "Today",
+              "LastMonth",
+              "ThisMonth",
+              "All"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SyncPeriod"
+              }
+            ]
           },
           "rootFolder": {
             "type": "string",
@@ -3601,7 +4297,17 @@
         "type": "object",
         "properties": {
           "syncPeriod": {
-            "$ref": "#/components/schemas/SyncPeriod"
+            "enum": [
+              "Today",
+              "LastMonth",
+              "ThisMonth",
+              "All"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SyncPeriod"
+              }
+            ]
           },
           "rootFolder": {
             "type": "string",
@@ -3650,8 +4356,7 @@
           "ThisMonth",
           "All"
         ],
-        "type": "integer",
-        "format": "int32"
+        "type": "string"
       },
       "TdmRelationshipObject": {
         "type": "object",
@@ -3661,7 +4366,12 @@
             "nullable": true
           },
           "links": {
-            "$ref": "#/components/schemas/RelationshipLinks"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RelationshipLinks"
+              }
+            ],
+            "nullable": true
           },
           "data": {
             "type": "array",
@@ -3714,7 +4424,13 @@
         "type": "object",
         "properties": {
           "establishmentsOfOriginExternalReference": {
-            "$ref": "#/components/schemas/ExternalReference"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalReference"
+              }
+            ],
+            "description": "External reference of approved establishments, which relates to a downstream service",
+            "nullable": true
           },
           "establishmentsOfOrigins": {
             "type": "array",


### PR DESCRIPTION
This PR changes our type generation based on a new temporary spec from BTMS.

Previously, all properties of an enum type were coming through as non nullable so they were mandated and did not match our example BTMS responses.

We also change how we generate our own open API spec so we can retain the nullable properties.