### PR TITLE
PHAIN-38: Add WireMock for stubbing BTMS

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="7.1.0" />
+    <PackageReference Include="WireMock.Net" Version="1.6.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Api/Configuration/BtmsOptions.cs
+++ b/src/Api/Configuration/BtmsOptions.cs
@@ -9,10 +9,12 @@ public class BtmsOptions
     public required string BaseUrl { get; init; }
 
     [Required]
-    public required string Username { get; init; }
+    public required string Password { get; init; }
+
+    public bool StubEnabled { get; init; } = false;
 
     [Required]
-    public required string Password { get; init; }
+    public required string Username { get; init; }
 
     public string BasicAuthCredential => Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"));
 }

--- a/src/Api/JsonApi/SingleOrManyDataConverterFactory.cs
+++ b/src/Api/JsonApi/SingleOrManyDataConverterFactory.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 namespace Defra.PhaImportNotifications.Api.JsonApi;
 
 /// <summary>
-/// Converts <see cref="SingleOrManyData{T}" /> to/from JSON.
+///     Converts <see cref="SingleOrManyData{T}" /> to/from JSON.
 /// </summary>
 public sealed class SingleOrManyDataConverterFactory : JsonConverterFactory
 {
@@ -18,14 +18,17 @@ public sealed class SingleOrManyDataConverterFactory : JsonConverterFactory
     }
 
     /// <inheritdoc />
-    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    public override System.Text.Json.Serialization.JsonConverter CreateConverter(
+        Type typeToConvert,
+        JsonSerializerOptions options
+    )
     {
         ArgumentNullException.ThrowIfNull(typeToConvert);
 
-        Type objectType = typeToConvert.GetGenericArguments()[0];
-        Type converterType = typeof(SingleOrManyDataConverter<>).MakeGenericType(objectType);
+        var objectType = typeToConvert.GetGenericArguments()[0];
+        var converterType = typeof(SingleOrManyDataConverter<>).MakeGenericType(objectType);
 
-        return (JsonConverter)Activator.CreateInstance(converterType)!;
+        return (System.Text.Json.Serialization.JsonConverter)Activator.CreateInstance(converterType)!;
     }
 
     private sealed class SingleOrManyDataConverter<T> : JsonObjectConverter<SingleOrManyData<T>>
@@ -38,8 +41,8 @@ public sealed class SingleOrManyDataConverterFactory : JsonConverterFactory
         )
         {
             List<T?> objects = [];
-            bool isManyData = false;
-            bool hasCompletedToMany = false;
+            var isManyData = false;
+            var hasCompletedToMany = false;
 
             do
             {

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -26,11 +26,6 @@ Log.Logger = new LoggerConfiguration().WriteTo.Console().CreateBootstrapLogger()
 try
 {
     var app = CreateWebApplication(args);
-    var btmsOptions = app.Services.GetRequiredService<IOptions<BtmsOptions>>().Value;
-
-    if (btmsOptions.StubEnabled)
-        app.Services.GetRequiredService<WireMockBtmsService>().Start();
-
     await app.RunAsync();
 }
 catch (Exception ex)
@@ -111,7 +106,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder)
         sp => sp.GetRequiredService<IOptions<BtmsOptions>>().Value.BasicAuthCredential
     );
     builder.Services.AddTransient<IBtmsService, StubBtmsService>();
-    builder.Services.AddSingleton<WireMockBtmsService>();
+    builder.Services.AddHostedService<WireMockBtmsService>();
 
     // calls outside the platform should be done using the named 'proxy' http client.
     builder.Services.AddHttpProxyClient(logger);

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -26,6 +26,11 @@ Log.Logger = new LoggerConfiguration().WriteTo.Console().CreateBootstrapLogger()
 try
 {
     var app = CreateWebApplication(args);
+    var btmsOptions = app.Services.GetRequiredService<IOptions<BtmsOptions>>().Value;
+
+    if (btmsOptions.StubEnabled)
+        app.Services.GetRequiredService<WireMockBtmsService>().Start();
+
     await app.RunAsync();
 }
 catch (Exception ex)
@@ -106,6 +111,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder)
         sp => sp.GetRequiredService<IOptions<BtmsOptions>>().Value.BasicAuthCredential
     );
     builder.Services.AddTransient<IBtmsService, StubBtmsService>();
+    builder.Services.AddSingleton<WireMockBtmsService>();
 
     // calls outside the platform should be done using the named 'proxy' http client.
     builder.Services.AddHttpProxyClient(logger);

--- a/src/Api/Services/Btms/StubBtmsService.cs
+++ b/src/Api/Services/Btms/StubBtmsService.cs
@@ -6,11 +6,16 @@ namespace Defra.PhaImportNotifications.Api.Services.Btms;
 [ExcludeFromCodeCoverage]
 public class StubBtmsService : IBtmsService
 {
-    public Task<IEnumerable<ImportNotification>> GetImportNotifications(CancellationToken cancellationToken) =>
-        Task.FromResult<IEnumerable<ImportNotification>>(new List<ImportNotification>());
+    public Task<IEnumerable<ImportNotification>> GetImportNotifications(CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IEnumerable<ImportNotification>>(new List<ImportNotification>());
+    }
 
     public Task<ImportNotification?> GetImportNotification(
         string chedReferenceNumber,
         CancellationToken cancellationToken
-    ) => Task.FromResult<ImportNotification?>(null);
+    )
+    {
+        return Task.FromResult<ImportNotification?>(null);
+    }
 }

--- a/src/Api/Services/Btms/WireMockBtmsService.cs
+++ b/src/Api/Services/Btms/WireMockBtmsService.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using Defra.PhaImportNotifications.Api.Configuration;
+using Microsoft.Extensions.Options;
 using WireMock.Admin.Requests;
 using WireMock.Logging;
 using WireMock.Server;
@@ -8,14 +10,27 @@ using WireMock.Settings;
 namespace Defra.PhaImportNotifications.Api.Services.Btms;
 
 [ExcludeFromCodeCoverage]
-public class WireMockBtmsService(ILogger<WireMockBtmsService> logger)
+public class WireMockBtmsService(IOptions<BtmsOptions> btmsOptions, ILogger<WireMockBtmsService> logger)
+    : IHostedService
 {
+    private readonly BtmsOptions _options = btmsOptions.Value;
     private readonly WireMockServerSettings _settings = new() { Logger = new WireMockLogger(logger), Port = 8090 };
+    private WireMockServer? _wireMockServer;
 
-    public void Start()
+    public Task StartAsync(CancellationToken cancellationToken)
     {
-        logger.LogInformation("Starting WireMock BTMS Service");
-        WireMockServer.Start(_settings);
+        if (!_options.StubEnabled)
+            return Task.CompletedTask;
+
+        logger.LogInformation("Starting BTMS WireMock server on http://localhost:{Port}", _settings.Port);
+        _wireMockServer = WireMockServer.Start(_settings);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _wireMockServer?.Stop();
+        return Task.CompletedTask;
     }
 
     private sealed class WireMockLogger(ILogger<WireMockBtmsService> wiremockLogger) : IWireMockLogger

--- a/src/Api/Services/Btms/WireMockBtmsService.cs
+++ b/src/Api/Services/Btms/WireMockBtmsService.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using WireMock.Admin.Requests;
+using WireMock.Logging;
+using WireMock.Server;
+using WireMock.Settings;
+
+namespace Defra.PhaImportNotifications.Api.Services.Btms;
+
+[ExcludeFromCodeCoverage]
+public class WireMockBtmsService(ILogger<WireMockBtmsService> logger)
+{
+    private readonly WireMockServerSettings _settings = new() { Logger = new WireMockLogger(logger), Port = 8090 };
+
+    public void Start()
+    {
+        logger.LogInformation("Starting WireMock BTMS Service");
+        WireMockServer.Start(_settings);
+    }
+
+    private sealed class WireMockLogger(ILogger<WireMockBtmsService> wiremockLogger) : IWireMockLogger
+    {
+        public void Debug(string formatString, params object[] args)
+        {
+            wiremockLogger.LogDebug(formatString, args);
+        }
+
+        public void Info(string formatString, params object[] args)
+        {
+            wiremockLogger.LogInformation(formatString, args);
+        }
+
+        public void Warn(string formatString, params object[] args)
+        {
+            wiremockLogger.LogWarning(formatString, args);
+        }
+
+        public void Error(string formatString, params object[] args)
+        {
+            wiremockLogger.LogError(formatString, args);
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            wiremockLogger.LogError(exception, message);
+        }
+
+        public void DebugRequestResponse(LogEntryModel logEntryModel, bool isAdminRequest)
+        {
+            var message = JsonSerializer.Serialize(logEntryModel, new JsonSerializerOptions { WriteIndented = true });
+            wiremockLogger.LogDebug("Admin[{0}] {1}", isAdminRequest, message);
+        }
+    }
+}

--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -26,5 +26,8 @@
         }
       }
     ]
+  },
+  "Btms": {
+    "StubEnabled": true
   }
 }

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -27,7 +27,7 @@
     ]
   },
   "Btms": {
-    "BaseUrl": "https://btms-local/",
+    "BaseUrl": "http://localhost:8090",
     "Username": "username",
     "Password": "password"
   }

--- a/tests/Api.IntegrationTests/Endpoints/EndpointTestBase.cs
+++ b/tests/Api.IntegrationTests/Endpoints/EndpointTestBase.cs
@@ -1,4 +1,6 @@
+using Defra.PhaImportNotifications.Api.Configuration;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Defra.PhaImportNotifications.Api.IntegrationTests.Endpoints;
@@ -13,7 +15,14 @@ public class EndpointTestBase<T> : IClassFixture<WebApplicationFactory<T>>
         _factory = factory;
     }
 
-    protected virtual void ConfigureTestServices(IServiceCollection services) { }
+    protected virtual void ConfigureTestServices(IServiceCollection services)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { { "Btms:StubEnabled", "false" } })
+            .Build();
+
+        services.Configure<BtmsOptions>(configuration.GetSection("Btms"));
+    }
 
     protected HttpClient CreateClient()
     {


### PR DESCRIPTION
This adds WireMock for stubbing BTMS responses which is enabled via the Btms_StubEnabled feature flag.

It is currently disabled for the integration tests until we've added the stubs for them to pass.