### PR TITLE
PHAIN-38: Allocate a random port for WireMock

### DIFF
--- a/src/Api/Configuration/BtmsOptions.cs
+++ b/src/Api/Configuration/BtmsOptions.cs
@@ -13,6 +13,8 @@ public class BtmsOptions
 
     public bool StubEnabled { get; init; } = false;
 
+    public int StubPort { get; init; } = 8090;
+
     [Required]
     public required string Username { get; init; }
 

--- a/src/Api/Services/Btms/WireMockBtmsService.cs
+++ b/src/Api/Services/Btms/WireMockBtmsService.cs
@@ -14,7 +14,13 @@ public class WireMockBtmsService(IOptions<BtmsOptions> btmsOptions, ILogger<Wire
     : IHostedService
 {
     private readonly BtmsOptions _options = btmsOptions.Value;
-    private readonly WireMockServerSettings _settings = new() { Logger = new WireMockLogger(logger), Port = 8090 };
+
+    private readonly WireMockServerSettings _settings = new()
+    {
+        Logger = new WireMockLogger(logger),
+        Port = btmsOptions.Value.StubPort,
+    };
+
     private WireMockServer? _wireMockServer;
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -22,8 +28,8 @@ public class WireMockBtmsService(IOptions<BtmsOptions> btmsOptions, ILogger<Wire
         if (!_options.StubEnabled)
             return Task.CompletedTask;
 
-        logger.LogInformation("Starting BTMS WireMock server on http://localhost:{Port}", _settings.Port);
         _wireMockServer = WireMockServer.Start(_settings);
+        logger.LogInformation("Starting BTMS WireMock server on http://localhost:{Port}", _wireMockServer.Port);
         return Task.CompletedTask;
     }
 

--- a/tests/Api.IntegrationTests/Endpoints/EndpointTestBase.cs
+++ b/tests/Api.IntegrationTests/Endpoints/EndpointTestBase.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using Defra.PhaImportNotifications.Api.Configuration;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
@@ -15,10 +17,30 @@ public class EndpointTestBase<T> : IClassFixture<WebApplicationFactory<T>>
         _factory = factory;
     }
 
+    private static int GetRandomPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        listener.Stop();
+        return port;
+    }
+
     protected virtual void ConfigureTestServices(IServiceCollection services)
     {
+        var btmsPort = GetRandomPort();
+
         var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?> { { "Btms:StubEnabled", "false" } })
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    { "Btms:BaseUrl", $"http://localhost:{btmsPort}" },
+                    { "Btms:StubEnabled", "true" },
+                    { "Btms:StubPort", btmsPort.ToString() },
+                }
+            )
             .Build();
 
         services.Configure<BtmsOptions>(configuration.GetSection("Btms"));


### PR DESCRIPTION
When running the integration tests, they attempt to start multiple instances of WireMock which fail because they are trying to use the same port.