### PR TITLE
PHAIN-99: Add Basic Authentication

### DIFF
--- a/.vacuum.yml
+++ b/.vacuum.yml
@@ -15,3 +15,5 @@ rules:
   # We may implement rate limiting but currently do not have it
   # https://quobix.com/vacuum/rules/owasp/owasp-rate-limit/
   owasp-rate-limit: false
+  # We're temporarily using Basic Auth
+  owasp-no-http-basic: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY tests/Api.IntegrationTests tests/Api.IntegrationTests
 RUN dotnet csharpier --check .
 
 RUN dotnet build --no-restore -c Release
-RUN swagger tofile --output openapi.json ./src/Api/bin/Release/net9.0/Defra.PhaImportNotifications.Api.dll v1
+RUN BasicAuth__Enabled=false swagger tofile --output openapi.json ./src/Api/bin/Release/net9.0/Defra.PhaImportNotifications.Api.dll v1
 RUN vacuum lint -d -r .vacuum.yml openapi.json
 
 RUN dotnet test --no-restore tests/Api.Tests

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ dependencies:
 
 generate-openapi-spec: dependencies
 	dotnet build -c Release --no-restore
-	swagger tofile --output openapi.json ./src/Api/bin/Release/net9.0/Defra.PhaImportNotifications.Api.dll v1
+	BasicAuth__Enabled=false swagger tofile --output openapi.json ./src/Api/bin/Release/net9.0/Defra.PhaImportNotifications.Api.dll v1
 
 lint-openapi-spec: generate-openapi-spec
 	docker run --rm -v "$(PWD):/work:ro" dshanley/vacuum lint -d -r .vacuum.yml openapi.json

--- a/src/Api/Authentication/BasicAuthenticationHandler.cs
+++ b/src/Api/Authentication/BasicAuthenticationHandler.cs
@@ -1,0 +1,61 @@
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Defra.PhaImportNotifications.Api.Configuration;
+using Defra.PhaImportNotifications.Api.Helpers;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Defra.PhaImportNotifications.Api.Authentication;
+
+public class BasicAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    IOptionsMonitor<BasicAuthOptions> basicAuthenticationOptions,
+    ILoggerFactory logger,
+    UrlEncoder encoder
+) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    private readonly BasicAuthOptions _authOptions = basicAuthenticationOptions.CurrentValue;
+
+    private static (string, string)? GetCredentials(StringValues header)
+    {
+        if (StringValues.IsNullOrEmpty(header))
+            return null;
+
+        try
+        {
+            var authHeader = AuthenticationHeaderValue.Parse(header!);
+            if (authHeader.Parameter is null)
+                return null;
+
+            return BasicAuthHelper.FromBasicAuth(authHeader.Parameter);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private AuthenticationTicket CreateAuthenticationTicket(string username)
+    {
+        var identity = new ClaimsIdentity([new Claim(ClaimTypes.Name, username)], "Basic");
+        return new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme.Name);
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!_authOptions.Enabled)
+            return Task.FromResult(AuthenticateResult.Success(CreateAuthenticationTicket("LocalDev")));
+
+        var credentials = GetCredentials(Request.Headers.Authorization);
+        if (credentials is null)
+            return Task.FromResult(AuthenticateResult.Fail("Invalid Authorization Header"));
+
+        var (username, password) = credentials.Value;
+        if (username != _authOptions.Username || password != _authOptions.Password)
+            return Task.FromResult(AuthenticateResult.Fail("Invalid Username or Password"));
+
+        return Task.FromResult(AuthenticateResult.Success(CreateAuthenticationTicket(username)));
+    }
+}

--- a/src/Api/Configuration/BasicAuthOptions.cs
+++ b/src/Api/Configuration/BasicAuthOptions.cs
@@ -1,0 +1,10 @@
+namespace Defra.PhaImportNotifications.Api.Configuration;
+
+public class BasicAuthOptions
+{
+    public bool Enabled { get; init; } = true;
+
+    public string Password { get; init; } = string.Empty;
+
+    public string Username { get; init; } = string.Empty;
+}

--- a/src/Api/Configuration/BasicAuthOptionsValidator.cs
+++ b/src/Api/Configuration/BasicAuthOptionsValidator.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Options;
+
+namespace Defra.PhaImportNotifications.Api.Configuration;
+
+public class BasicAuthOptionsValidator : IValidateOptions<BasicAuthOptions>
+{
+    public ValidateOptionsResult Validate(string? name, BasicAuthOptions options)
+    {
+        if (!options.Enabled)
+            return ValidateOptionsResult.Success;
+
+        if (string.IsNullOrEmpty(options.Username) || string.IsNullOrEmpty(options.Password))
+            return ValidateOptionsResult.Fail("Basic Auth is enabled but the Username or Password is empty.");
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Api/Configuration/BtmsOptions.cs
+++ b/src/Api/Configuration/BtmsOptions.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel.DataAnnotations;
-using System.Text;
+using Defra.PhaImportNotifications.Api.Helpers;
 
 namespace Defra.PhaImportNotifications.Api.Configuration;
 
@@ -14,5 +14,5 @@ public class BtmsOptions
     [Required]
     public required string Username { get; init; }
 
-    public string BasicAuthCredential => Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"));
+    public string BasicAuthCredential => BasicAuthHelper.CreateBasicAuth(Username, Password);
 }

--- a/src/Api/Endpoints/ImportNotifications/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/ImportNotifications/EndpointRouteBuilderExtensions.cs
@@ -10,6 +10,7 @@ public static class EndpointRouteBuilderExtensions
     public static void MapImportNotificationsEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapGet("import-notifications", GetUpdated)
+            .RequireAuthorization()
             .WithName("UpdatedImportNotifications")
             .WithTags("Import Notifications")
             .WithSummary("Get updated Import Notifications")
@@ -21,6 +22,7 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status500InternalServerError);
 
         app.MapGet("import-notifications/{chedReferenceNumber}/", Get)
+            .RequireAuthorization()
             .WithName("ImportNotificationsByChedReferenceNumber")
             .WithTags("Import Notifications")
             .WithSummary("Get Import Notification")

--- a/src/Api/Extensions/BasicAuthenticationExtensions.cs
+++ b/src/Api/Extensions/BasicAuthenticationExtensions.cs
@@ -1,0 +1,18 @@
+using Defra.PhaImportNotifications.Api.Authentication;
+using Defra.PhaImportNotifications.Api.Configuration;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace Defra.PhaImportNotifications.Api.Extensions;
+
+public static class BasicAuthenticationExtensions
+{
+    public static void AddBasicAuthentication(this IServiceCollection services)
+    {
+        services.AddSingleton<IValidateOptions<BasicAuthOptions>, BasicAuthOptionsValidator>();
+        services.AddOptions<BasicAuthOptions>().BindConfiguration("BasicAuth").ValidateOptions();
+
+        services.AddAuthentication().AddScheme<AuthenticationSchemeOptions, BasicAuthenticationHandler>("Basic", null);
+        services.AddAuthorization();
+    }
+}

--- a/src/Api/Helpers/BasicAuthHelper.cs
+++ b/src/Api/Helpers/BasicAuthHelper.cs
@@ -1,0 +1,23 @@
+using System.Text;
+
+namespace Defra.PhaImportNotifications.Api.Helpers;
+
+public static class BasicAuthHelper
+{
+    public static string CreateBasicAuthHeader(string username, string password)
+    {
+        return $"Basic {CreateBasicAuth(username, password)}";
+    }
+
+    public static string CreateBasicAuth(string username, string password)
+    {
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+    }
+
+    public static (string, string) FromBasicAuth(string basicAuth)
+    {
+        var credentialBytes = Convert.FromBase64String(basicAuth);
+        var credentials = Encoding.UTF8.GetString(credentialBytes).Split(":", 2);
+        return (credentials[0], credentials[1]);
+    }
+}

--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -27,6 +27,9 @@
       }
     ]
   },
+  "BasicAuth": {
+    "Enabled": false
+  },
   "BtmsStub": {
     "Enabled": true
   }

--- a/src/Api/appsettings.IntegrationTests.json
+++ b/src/Api/appsettings.IntegrationTests.json
@@ -1,4 +1,8 @@
 {
+  "BasicAuth": {
+    "Username": "pha",
+    "Password": "onetwothree"
+  },
   "BtmsStub": {
     "Enabled": false
   }

--- a/tests/Api.IntegrationTests/Endpoints/EndpointTestBase.cs
+++ b/tests/Api.IntegrationTests/Endpoints/EndpointTestBase.cs
@@ -1,5 +1,4 @@
 using System.Net.Http.Headers;
-using Defra.PhaImportNotifications.Api.Configuration;
 using Defra.PhaImportNotifications.Api.Helpers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -20,10 +19,7 @@ public class EndpointTestBase<T> : IClassFixture<TestWebApplicationFactory<T>>
         _factory.OutputHelper = outputHelper;
     }
 
-    protected virtual void ConfigureTestServices(IServiceCollection services)
-    {
-        services.AddSingleton<BasicAuthOptions>(_ => new BasicAuthOptions { Username = "abcd", Password = "defg" });
-    }
+    protected virtual void ConfigureTestServices(IServiceCollection services) { }
 
     protected HttpClient CreateClient()
     {

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.cs
@@ -13,9 +13,6 @@ namespace Defra.PhaImportNotifications.Api.IntegrationTests.Endpoints.ImportNoti
 
 public class GetTests : EndpointTestBase<Program>, IClassFixture<WireMockContext>
 {
-    private WireMockServer WireMock { get; }
-    private HttpClient HttpClient { get; }
-
     public GetTests(TestWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper, WireMockContext context)
         : base(factory, outputHelper)
     {
@@ -23,6 +20,9 @@ public class GetTests : EndpointTestBase<Program>, IClassFixture<WireMockContext
         WireMock.Reset();
         HttpClient = context.HttpClient;
     }
+
+    private WireMockServer WireMock { get; }
+    private HttpClient HttpClient { get; }
 
     [Fact]
     public async Task Get_WhenFound_ShouldSucceed()
@@ -54,6 +54,17 @@ public class GetTests : EndpointTestBase<Program>, IClassFixture<WireMockContext
         var response = await client.GetAsync(Testing.Endpoints.ImportNotifications.Get());
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_WhenNotAuthenticated_ReturnsUnauthorized()
+    {
+        var client = CreateClient();
+        client.DefaultRequestHeaders.Authorization = null;
+
+        var response = await client.GetAsync(Testing.Endpoints.ImportNotifications.Get());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     protected override void ConfigureTestServices(IServiceCollection services)

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetUpdatedTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetUpdatedTests.cs
@@ -1,7 +1,9 @@
+using System.Net;
 using AutoFixture;
 using Defra.PhaImportNotifications.Api.Services.Btms;
 using Defra.PhaImportNotifications.Contracts;
 using Defra.PhaImportNotifications.Testing;
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit.Abstractions;
@@ -46,6 +48,17 @@ public class GetUpdatedTests(TestWebApplicationFactory<Program> factory, ITestOu
         var response = await client.GetStringAsync(Testing.Endpoints.ImportNotifications.GetUpdated());
 
         await Verify(response);
+    }
+
+    [Fact]
+    public async Task Get_WhenNotAuthenticated_ReturnsUnauthorized()
+    {
+        var client = CreateClient();
+        client.DefaultRequestHeaders.Authorization = null;
+
+        var response = await client.GetAsync(Testing.Endpoints.ImportNotifications.GetUpdated());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     protected override void ConfigureTestServices(IServiceCollection services)

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -3744,6 +3744,11 @@
       }
     }
   },
+  "security": [
+    {
+      "Basic": [ ]
+    }
+  ],
   "tags": [
     {
       "name": "Import Notifications",

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -3735,6 +3735,13 @@
         },
         "additionalProperties": false
       }
+    },
+    "securitySchemes": {
+      "Basic": {
+        "type": "http",
+        "description": "Basic authentication using the Authorization header",
+        "scheme": "Basic"
+      }
     }
   },
   "tags": [

--- a/tests/Api.Tests/Authentication/BasicAuthenticationHandlerTests.cs
+++ b/tests/Api.Tests/Authentication/BasicAuthenticationHandlerTests.cs
@@ -13,7 +13,7 @@ namespace Defra.PhaImportNotifications.Api.Tests.Authentication;
 
 public class BasicAuthenticationHandlerTests
 {
-    private async Task<BasicAuthenticationHandler> CreateHandler(TestHandlerOptions options)
+    private static async Task<BasicAuthenticationHandler> CreateHandler(TestHandlerOptions options)
     {
         var authSchemeOptions = new AuthenticationSchemeOptions { TimeProvider = Substitute.For<TimeProvider>() };
 
@@ -49,7 +49,7 @@ public class BasicAuthenticationHandlerTests
     public async Task HandleAuthenticateAsync_WhenDisabled_ReturnsSuccess()
     {
         var context = new DefaultHttpContext();
-        context.Request.Headers["Authorization"] = "";
+        context.Request.Headers.Authorization = "";
 
         var handler = await CreateHandler(new TestHandlerOptions { AuthEnabled = false, HttpContext = context });
 
@@ -61,7 +61,7 @@ public class BasicAuthenticationHandlerTests
     public async Task HandleAuthenticateAsync_WithNoAuthorizationHeader_FailsWithInvalidAuthorizationHeader()
     {
         var context = new DefaultHttpContext();
-        context.Request.Headers["Authorization"] = "";
+        context.Request.Headers.Authorization = "";
 
         var handler = await CreateHandler(new TestHandlerOptions { HttpContext = context });
 
@@ -79,7 +79,7 @@ public class BasicAuthenticationHandlerTests
     )
     {
         var context = new DefaultHttpContext();
-        context.Request.Headers["Authorization"] = authorizationHeader;
+        context.Request.Headers.Authorization = authorizationHeader;
 
         var handler = await CreateHandler(new TestHandlerOptions { HttpContext = context });
 
@@ -91,7 +91,7 @@ public class BasicAuthenticationHandlerTests
     public async Task HandleAuthenticateAsync_WithIncorrectUsernameOrPassword_FailsWithInvalidUsernameOrPassword()
     {
         var context = new DefaultHttpContext();
-        context.Request.Headers["Authorization"] = BasicAuthHelper.CreateBasicAuthHeader(
+        context.Request.Headers.Authorization = BasicAuthHelper.CreateBasicAuthHeader(
             "invalid-username",
             "invalid-password"
         );
@@ -110,7 +110,7 @@ public class BasicAuthenticationHandlerTests
         const string password = "real-password";
         const string username = "real-username";
 
-        context.Request.Headers["Authorization"] = BasicAuthHelper.CreateBasicAuthHeader(username, password);
+        context.Request.Headers.Authorization = BasicAuthHelper.CreateBasicAuthHeader(username, password);
 
         var handler = await CreateHandler(
             new TestHandlerOptions

--- a/tests/Api.Tests/Authentication/BasicAuthenticationHandlerTests.cs
+++ b/tests/Api.Tests/Authentication/BasicAuthenticationHandlerTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Encodings.Web;
+using Defra.PhaImportNotifications.Api.Authentication;
+using Defra.PhaImportNotifications.Api.Configuration;
+using Defra.PhaImportNotifications.Api.Helpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Defra.PhaImportNotifications.Api.Tests.Authentication;
+
+public class BasicAuthenticationHandlerTests
+{
+    private async Task<BasicAuthenticationHandler> CreateHandler(TestHandlerOptions options)
+    {
+        var authSchemeOptions = new AuthenticationSchemeOptions { TimeProvider = Substitute.For<TimeProvider>() };
+
+        var mockSchemeOptions = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
+        mockSchemeOptions.Get("Basic").Returns(authSchemeOptions);
+
+        var mockBasicAuthOptions = Substitute.For<IOptionsMonitor<BasicAuthOptions>>();
+        mockBasicAuthOptions.CurrentValue.Returns(
+            new BasicAuthOptions
+            {
+                Enabled = options.AuthEnabled,
+                Password = options.Password,
+                Username = options.Username,
+            }
+        );
+
+        var handler = new BasicAuthenticationHandler(
+            mockSchemeOptions,
+            mockBasicAuthOptions,
+            Substitute.For<ILoggerFactory>(),
+            Substitute.For<UrlEncoder>()
+        );
+
+        await handler.InitializeAsync(
+            new AuthenticationScheme("Basic", null, typeof(BasicAuthenticationHandler)),
+            options.HttpContext
+        );
+
+        return handler;
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_WhenDisabled_ReturnsSuccess()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["Authorization"] = "";
+
+        var handler = await CreateHandler(new TestHandlerOptions { AuthEnabled = false, HttpContext = context });
+
+        var result = await handler.AuthenticateAsync();
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_WithNoAuthorizationHeader_FailsWithInvalidAuthorizationHeader()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["Authorization"] = "";
+
+        var handler = await CreateHandler(new TestHandlerOptions { HttpContext = context });
+
+        var result = await handler.AuthenticateAsync();
+        result.Failure?.Message.Should().Be("Invalid Authorization Header");
+    }
+
+    [Theory]
+    [InlineData("Basic ")] // username:
+    [InlineData("Basic dXNlcm5hbWVwYXNzd29yZA==")] // usernamepassword
+    [InlineData("Basic blob")] // blob
+    [InlineData("Bearer blob")] // also blob
+    public async Task HandleAuthenticateAsync_WithAnInvalidHeader_FailsWithInvalidAuthorizationHeader(
+        string authorizationHeader
+    )
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["Authorization"] = authorizationHeader;
+
+        var handler = await CreateHandler(new TestHandlerOptions { HttpContext = context });
+
+        var result = await handler.AuthenticateAsync();
+        result.Failure?.Message.Should().Be("Invalid Authorization Header");
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_WithIncorrectUsernameOrPassword_FailsWithInvalidUsernameOrPassword()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["Authorization"] = BasicAuthHelper.CreateBasicAuthHeader(
+            "invalid-username",
+            "invalid-password"
+        );
+
+        var handler = await CreateHandler(new TestHandlerOptions { HttpContext = context });
+
+        var result = await handler.AuthenticateAsync();
+        result.Failure?.Message.Should().Be("Invalid Username or Password");
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_WithCorrectUsernameAndPassword_ReturnsSuccess()
+    {
+        var context = new DefaultHttpContext();
+
+        const string password = "real-password";
+        const string username = "real-username";
+
+        context.Request.Headers["Authorization"] = BasicAuthHelper.CreateBasicAuthHeader(username, password);
+
+        var handler = await CreateHandler(
+            new TestHandlerOptions
+            {
+                HttpContext = context,
+                Password = password,
+                Username = username,
+            }
+        );
+
+        var result = await handler.AuthenticateAsync();
+        result.Succeeded.Should().BeTrue();
+    }
+
+    private class TestHandlerOptions
+    {
+        public bool AuthEnabled { get; init; } = true;
+        public required HttpContext HttpContext { get; init; }
+        public string Password { get; init; } = "password";
+        public string Username { get; init; } = "username";
+    }
+}

--- a/tests/Api.Tests/Configuration/BasicAuthOptionsValidatorTests.cs
+++ b/tests/Api.Tests/Configuration/BasicAuthOptionsValidatorTests.cs
@@ -1,0 +1,32 @@
+using Defra.PhaImportNotifications.Api.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+
+namespace Defra.PhaImportNotifications.Api.Tests.Configuration;
+
+public class BasicAuthOptionsValidatorTests
+{
+    private readonly BasicAuthOptionsValidator _validator = new();
+
+    [Fact]
+    public void IfNotEnabled_ValidatesSuccessfully()
+    {
+        var options = new BasicAuthOptions { Enabled = false };
+        _validator.Validate("", options).Should().Be(ValidateOptionsResult.Success);
+    }
+
+    [Theory]
+    [InlineData("username", "", true)]
+    [InlineData("", "password", true)]
+    [InlineData("username", "password", false)]
+    public void IfEnabled_TheUsernameAndPasswordMustBePresent_OrItFails(string username, string password, bool failed)
+    {
+        var options = new BasicAuthOptions
+        {
+            Enabled = true,
+            Password = password,
+            Username = username,
+        };
+        _validator.Validate("", options).Failed.Should().Be(failed);
+    }
+}

--- a/tests/Api.Tests/Helpers/BasicAuthHelperTests.cs
+++ b/tests/Api.Tests/Helpers/BasicAuthHelperTests.cs
@@ -1,0 +1,32 @@
+using Defra.PhaImportNotifications.Api.Helpers;
+using FluentAssertions;
+
+namespace Defra.PhaImportNotifications.Api.Tests.Helpers;
+
+public class BasicAuthHelperTests
+{
+    private readonly string BasicAuthValue = "dXNlcm5hbWU6cGFzc3dvcmQ="; // username: password
+    private readonly string Passsword = "password";
+    private readonly string Username = "username";
+
+    [Fact]
+    public void CreateBasicAuthHeader_ReturnsTheCorrectAuthHeader()
+    {
+        var result = BasicAuthHelper.CreateBasicAuthHeader(Username, Passsword);
+        result.Should().Be($"Basic {BasicAuthValue}");
+    }
+
+    [Fact]
+    public void CreateBasicAuth_ReturnsTheCorrectValue()
+    {
+        var result = BasicAuthHelper.CreateBasicAuth(Username, Passsword);
+        result.Should().Be(BasicAuthValue);
+    }
+
+    [Fact]
+    public void FromBasicAuth_ReturnsTheCorrectUsernameAndPassword()
+    {
+        var result = BasicAuthHelper.FromBasicAuth(BasicAuthValue);
+        result.Should().Be((Username, Passsword));
+    }
+}


### PR DESCRIPTION
We're going to use Basic Auth until our auth provider is ready.
This change adds it and updates the OpenAPI spec to require the Authorization header.