### PR TITLE
Add from and to filters when looking for import notification updates

### DIFF
--- a/src/Api/Configuration/BtmsOptions.cs
+++ b/src/Api/Configuration/BtmsOptions.cs
@@ -15,4 +15,6 @@ public class BtmsOptions
     public required string Username { get; init; }
 
     public string BasicAuthCredential => BasicAuthHelper.CreateBasicAuth(Username, Password);
+
+    public int PageSize { get; init; } = 1000;
 }

--- a/src/Api/Endpoints/ImportNotifications/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/ImportNotifications/EndpointRouteBuilderExtensions.cs
@@ -46,11 +46,16 @@ public static class EndpointRouteBuilderExtensions
         CancellationToken cancellationToken
     )
     {
-        var notifications = await btmsService.GetImportNotificationUpdates(request.Bcp, cancellationToken);
+        var notifications = await btmsService.GetImportNotificationUpdates(
+            request.Bcp,
+            request.From,
+            request.To,
+            cancellationToken
+        );
         var updated = notifications.Select(x => new UpdatedImportNotification
         {
             Updated = x.Updated,
-            ReferenceNumber = x.ReferenceNumber!,
+            ReferenceNumber = x.ReferenceNumber,
             Links = new UpdatedImportNotificationLinks
             {
                 ImportNotification = new Uri($"/import-notifications/{x.ReferenceNumber}"),

--- a/src/Api/Endpoints/ImportNotifications/UpdatedImportNotificationRequest.cs
+++ b/src/Api/Endpoints/ImportNotifications/UpdatedImportNotificationRequest.cs
@@ -12,7 +12,7 @@ public sealed class UpdatedImportNotificationRequest : IDateTimeRangeDefinition
     public required string[] Bcp { get; init; }
 
     [Description(
-        "Filter import notifications updated after this date and time. "
+        "Filter import notifications updated at this date and time or after this date and time. "
             + " Expected value is UTC using format ISO 8601-1:2019"
     )]
     [FromQuery(Name = "from")]

--- a/src/Api/JsonApi/ComparisonOperator.cs
+++ b/src/Api/JsonApi/ComparisonOperator.cs
@@ -4,5 +4,7 @@ public enum ComparisonOperator
 {
     Equals,
     GreaterThan,
+    GreaterOrEqual,
     LessThan,
+    LessOrEqual,
 }

--- a/src/Api/Services/Btms/BtmsService.cs
+++ b/src/Api/Services/Btms/BtmsService.cs
@@ -7,6 +7,8 @@ public class BtmsService(JsonApiClient jsonApiClient) : IBtmsService
 {
     public async Task<IEnumerable<ImportNotificationUpdate>> GetImportNotificationUpdates(
         string[] bcp,
+        DateTime from,
+        DateTime to,
         CancellationToken cancellationToken
     )
     {
@@ -16,6 +18,8 @@ public class BtmsService(JsonApiClient jsonApiClient) : IBtmsService
                 new AnyExpression("_PointOfEntry", bcp),
                 new AnyExpression("importNotificationType", Enum.GetNames<ImportNotificationTypeEnum>()),
                 new NotExpression(new ComparisonExpression(ComparisonOperator.Equals, "status", "Draft")),
+                new ComparisonExpression(ComparisonOperator.GreaterOrEqual, "updated", from.ToString("O")),
+                new ComparisonExpression(ComparisonOperator.LessThan, "updated", to.ToString("O")),
             ]
         );
         var fields = new[] { new FieldExpression("import-notifications", ["updated", "referenceNumber"]) };

--- a/src/Api/Services/Btms/BtmsService.cs
+++ b/src/Api/Services/Btms/BtmsService.cs
@@ -1,9 +1,11 @@
+using Defra.PhaImportNotifications.Api.Configuration;
 using Defra.PhaImportNotifications.Api.JsonApi;
 using Defra.PhaImportNotifications.Contracts;
+using Microsoft.Extensions.Options;
 
 namespace Defra.PhaImportNotifications.Api.Services.Btms;
 
-public class BtmsService(JsonApiClient jsonApiClient) : IBtmsService
+public class BtmsService(JsonApiClient jsonApiClient, IOptions<BtmsOptions> btmsOptions) : IBtmsService
 {
     public async Task<IEnumerable<ImportNotificationUpdate>> GetImportNotificationUpdates(
         string[] bcp,
@@ -24,7 +26,7 @@ public class BtmsService(JsonApiClient jsonApiClient) : IBtmsService
         );
         var fields = new[] { new FieldExpression("import-notifications", ["updated", "referenceNumber"]) };
         var document = await jsonApiClient.Get(
-            new RequestUri("api/import-notifications", filter, fields, PageSize: 1000),
+            new RequestUri("api/import-notifications", filter, fields, btmsOptions.Value.PageSize),
             cancellationToken
         );
 

--- a/src/Api/Services/Btms/IBtmsService.cs
+++ b/src/Api/Services/Btms/IBtmsService.cs
@@ -6,6 +6,8 @@ public interface IBtmsService
 {
     Task<IEnumerable<ImportNotificationUpdate>> GetImportNotificationUpdates(
         string[] bcp,
+        DateTime from,
+        DateTime to,
         CancellationToken cancellationToken
     );
     Task<ImportNotification?> GetImportNotification(string chedReferenceNumber, CancellationToken cancellationToken);

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Defra.PhaImportNotifications.Api.Configuration;
 using Defra.PhaImportNotifications.Api.JsonApi;
 using Defra.PhaImportNotifications.Api.Services.Btms;
 using Defra.PhaImportNotifications.BtmsStub;
@@ -6,6 +7,7 @@ using Defra.PhaImportNotifications.Testing;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using WireMock.Server;
 using Xunit.Abstractions;
 
@@ -72,7 +74,16 @@ public class GetTests : EndpointTestBase<Program>, IClassFixture<WireMockContext
         base.ConfigureTestServices(services);
 
         services.AddTransient<IBtmsService>(_ => new BtmsService(
-            new JsonApiClient(HttpClient, NullLogger<JsonApiClient>.Instance)
+            new JsonApiClient(HttpClient, NullLogger<JsonApiClient>.Instance),
+            new OptionsWrapper<BtmsOptions>(
+                new BtmsOptions
+                {
+                    BaseUrl = "http://base-url",
+                    Password = "password",
+                    Username = "username",
+                    PageSize = 100,
+                }
+            )
         ));
     }
 }

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetUpdatedTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetUpdatedTests.cs
@@ -47,9 +47,9 @@ public class GetUpdatedTests(TestWebApplicationFactory<Program> factory, ITestOu
             );
 
         var url = Testing.Endpoints.ImportNotifications.GetUpdatedValid(
-            bcp: validRequest.Bcp,
-            from: validRequest.From.ToString("O"),
-            to: validRequest.To.ToString("O")
+            validRequest.Bcp,
+            validRequest.From.ToString("O"),
+            validRequest.To.ToString("O")
         );
 
         var response = await client.GetStringAsync(url);
@@ -69,7 +69,7 @@ public class GetUpdatedTests(TestWebApplicationFactory<Program> factory, ITestOu
     )
     {
         var client = CreateClient();
-        var url = Testing.Endpoints.ImportNotifications.GetUpdated(from, to, bcp);
+        var url = Testing.Endpoints.ImportNotifications.GetUpdated(bcp, from, to);
 
         var response = await client.GetAsync(url);
         var content = await response.Content.ReadAsStringAsync();
@@ -82,9 +82,9 @@ public class GetUpdatedTests(TestWebApplicationFactory<Program> factory, ITestOu
     {
         var client = CreateClient();
         var url = Testing.Endpoints.ImportNotifications.GetUpdated(
-            DateTime.UtcNow.AddSeconds(-60).ToString("O"),
-            DateTime.UtcNow.AddSeconds(-29).ToString("O"),
-            ["bcp1"]
+            ["bcp1"],
+            from: DateTime.UtcNow.AddSeconds(-60).ToString("O"),
+            to: DateTime.UtcNow.AddSeconds(-29).ToString("O")
         );
 
         var response = await client.GetAsync(url);

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -41,11 +41,11 @@
           {
             "name": "from",
             "in": "query",
-            "description": "Filter import notifications updated after this date and time.  Expected value is UTC using format ISO 8601-1:2019",
+            "description": "Filter import notifications updated at this date and time or after this date and time.  Expected value is UTC using format ISO 8601-1:2019",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "Filter import notifications updated after this date and time.  Expected value is UTC using format ISO 8601-1:2019",
+              "description": "Filter import notifications updated at this date and time or after this date and time.  Expected value is UTC using format ISO 8601-1:2019",
               "format": "date-time"
             }
           },

--- a/tests/Api.Tests/JsonApi/FilterTests.cs
+++ b/tests/Api.Tests/JsonApi/FilterTests.cs
@@ -9,8 +9,12 @@ public class FilterTests
     [InlineData(ComparisonOperator.Equals, "value'1", "equals(field1,'value''1')")]
     [InlineData(ComparisonOperator.GreaterThan, "value1", "greaterThan(field1,'value1')")]
     [InlineData(ComparisonOperator.GreaterThan, "value'1", "greaterThan(field1,'value''1')")]
+    [InlineData(ComparisonOperator.GreaterOrEqual, "value1", "greaterOrEqual(field1,'value1')")]
+    [InlineData(ComparisonOperator.GreaterOrEqual, "value'1", "greaterOrEqual(field1,'value''1')")]
     [InlineData(ComparisonOperator.LessThan, "value1", "lessThan(field1,'value1')")]
     [InlineData(ComparisonOperator.LessThan, "value'1", "lessThan(field1,'value''1')")]
+    [InlineData(ComparisonOperator.LessOrEqual, "value1", "lessOrEqual(field1,'value1')")]
+    [InlineData(ComparisonOperator.LessOrEqual, "value'1", "lessOrEqual(field1,'value''1')")]
     public void ComparisonExpression_ToString_AsExpected(ComparisonOperator @operator, string value, string expected)
     {
         var subject = new ComparisonExpression(@operator, "field1", value);

--- a/tests/Api.Tests/Services/Btms/BtmsServiceTests.cs
+++ b/tests/Api.Tests/Services/Btms/BtmsServiceTests.cs
@@ -1,9 +1,11 @@
+using Defra.PhaImportNotifications.Api.Configuration;
 using Defra.PhaImportNotifications.Api.Endpoints.ImportNotifications;
 using Defra.PhaImportNotifications.Api.JsonApi;
 using Defra.PhaImportNotifications.Api.Services.Btms;
 using Defra.PhaImportNotifications.BtmsStub;
 using Defra.PhaImportNotifications.Testing;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using ChedReferenceNumbers = Defra.PhaImportNotifications.Testing.ChedReferenceNumbers;
 
 namespace Defra.PhaImportNotifications.Api.Tests.Services.Btms;
@@ -12,7 +14,18 @@ public class BtmsServiceTests(WireMockContextQueryParameterNoComma context)
     : WireMockTestBase<WireMockContextQueryParameterNoComma>(context)
 {
     private BtmsService Subject { get; } =
-        new(new JsonApiClient(context.HttpClient, NullLogger<JsonApiClient>.Instance));
+        new(
+            new JsonApiClient(context.HttpClient, NullLogger<JsonApiClient>.Instance),
+            new OptionsWrapper<BtmsOptions>(
+                new BtmsOptions
+                {
+                    BaseUrl = "http://base-url",
+                    Password = "password",
+                    Username = "username",
+                    PageSize = 100,
+                }
+            )
+        );
 
     private UpdatedImportNotificationRequest ValidRequest { get; } =
         new()
@@ -38,7 +51,7 @@ public class BtmsServiceTests(WireMockContextQueryParameterNoComma context)
                         + ")"
                 )
                 .WithJsonApiParam("fields[import-notifications]", "updated,referenceNumber")
-                .WithJsonApiParam("page[size]", "1000")
+                .WithJsonApiParam("page[size]", "100")
         );
 
         var result = await Subject.GetImportNotificationUpdates(

--- a/tests/Testing/Endpoints.cs
+++ b/tests/Testing/Endpoints.cs
@@ -8,10 +8,10 @@ public static class Endpoints
     {
         private const string Root = "/import-notifications";
 
-        public static string GetUpdatedValid(string? from = null, string? to = null, string[]? bcp = null) =>
-            GetUpdated(from ?? "2024-12-11T13:00:00Z", to ?? "2024-12-11T13:30:00Z", bcp ?? ["bcp"]);
+        public static string GetUpdatedValid(string[]? bcp = null, string? from = null, string? to = null) =>
+            GetUpdated(bcp ?? ["bcp"], from ?? "2024-12-11T13:00:00Z", to ?? "2024-12-11T13:30:00Z");
 
-        public static string GetUpdated(string? from = null, string? to = null, string[]? bcp = null)
+        public static string GetUpdated(string[]? bcp = null, string? from = null, string? to = null)
         {
             var query = new QueryBuilder();
 


### PR DESCRIPTION
As per PR title.

Main point to note is that we filter BTMS by greater than or equal to the from date we are given and then less than the to date we are given. This will allow call ranges from our consumers to succeed without us dropping any data.

~Should we update the open API docs to indicate this behaviour?~ Agreed that we should update and a change has been included.

Also page PageSize configurable when calling BTMS for updates. Naming is generic but it's only used when retrieving updates. If we ever need multiple page size values then we can implement it then.