### PR TITLE
Add ext-test environment config

### DIFF
--- a/src/Api/appsettings.cdp.Ext-test.json
+++ b/src/Api/appsettings.cdp.Ext-test.json
@@ -1,0 +1,8 @@
+{
+  "Btms": {
+    "BaseUrl": "http://localhost:8090"
+  },
+  "BtmsStub": {
+    "Enabled": true
+  }
+}


### PR DESCRIPTION
As per PR title.

This config sets the API to use the stub in external test.