### PR TITLE
Set the open API server host for prod and external test

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -85,7 +85,12 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {
-        c.AddServer(new OpenApiServer { Url = "https://localhost" });
+        c.AddServer(
+            new OpenApiServer
+            {
+                Url = "https://" + (builder.Configuration.GetValue<string>("OpenApi:Host") ?? "localhost"),
+            }
+        );
         c.AddSecurityDefinition(
             "Basic",
             new OpenApiSecurityScheme

--- a/src/Api/appsettings.IntegrationTests.json
+++ b/src/Api/appsettings.IntegrationTests.json
@@ -5,5 +5,8 @@
   },
   "BtmsStub": {
     "Enabled": false
+  },
+  "OpenApi": {
+    "Host": "integration-test-host"
   }
 }

--- a/src/Api/appsettings.cdp.Ext-test.json
+++ b/src/Api/appsettings.cdp.Ext-test.json
@@ -4,5 +4,8 @@
   },
   "BtmsStub": {
     "Enabled": true
+  },
+  "OpenApi": {
+    "Host": "pha-import-notifications.api.test.defra.gov.uk"
   }
 }

--- a/src/Api/appsettings.cdp.Prod.json
+++ b/src/Api/appsettings.cdp.Prod.json
@@ -1,5 +1,8 @@
 {
   "BtmsStub": {
     "Enabled": false
+  },
+  "OpenApi": {
+    "Host": "pha-import-notifications.api.defra.gov.uk"
   }
 }

--- a/tests/Api.IntegrationTests/Endpoints/EndpointTestBase.cs
+++ b/tests/Api.IntegrationTests/Endpoints/EndpointTestBase.cs
@@ -1,6 +1,5 @@
 using System.Net.Http.Headers;
 using Defra.PhaImportNotifications.Api.Helpers;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,7 +34,6 @@ public class EndpointTestBase : IClassFixture<ApiWebApplicationFactory>
     {
         var builder = _factory.WithWebHostBuilder(builder =>
         {
-            builder.UseEnvironment("IntegrationTests");
             builder.ConfigureTestServices(ConfigureTestServices);
         });
 

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -12,7 +12,7 @@
   },
   "servers": [
     {
-      "url": "https://localhost"
+      "url": "https://integration-test-host"
     }
   ],
   "paths": {

--- a/tests/Api.IntegrationTests/TestWebApplicationFactory.cs
+++ b/tests/Api.IntegrationTests/TestWebApplicationFactory.cs
@@ -17,6 +17,7 @@ public class TestWebApplicationFactory<T> : WebApplicationFactory<T>, ITestOutpu
     {
         builder.ConfigureLogging(config => config.AddXUnit(this));
         builder.UseSetting("integrationTest", "true");
+        builder.UseEnvironment("IntegrationTests");
     }
 
     protected override IHost CreateHost(IHostBuilder builder)


### PR DESCRIPTION
As per PR title.

This approach was chosen as the host values don't map to CDP environments and there will be load balancers obscuring being to work it our automatically unless we start messing with HTTP headers so for now, this is kept simple.

Also worth noting that all lower CDP environments will still use localhost.