### PR TITLE
PHAIN-41: Add BCPs to authenticated user claims

### DIFF
--- a/src/Api/Authentication/PhaClaimTypes.cs
+++ b/src/Api/Authentication/PhaClaimTypes.cs
@@ -1,0 +1,6 @@
+namespace Defra.PhaImportNotifications.Api.Authentication;
+
+public static class PhaClaimTypes
+{
+    public const string Bcp = "Bcp";
+}

--- a/src/Api/Configuration/AclOptions.cs
+++ b/src/Api/Configuration/AclOptions.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Defra.PhaImportNotifications.Api.Configuration;
+
+public class AclOptions
+{
+    public Dictionary<string, ClientConfig> Clients { get; init; } = new();
+
+    public class ClientConfig
+    {
+        [Required]
+        public required List<string> Bcps { get; init; }
+    }
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -63,12 +63,10 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
     // Configure logging to use the CDP Platform standards.
     builder.Services.AddHttpContextAccessor();
     if (!integrationTest)
-    {
         // Configuring Serilog below wipes out the framework logging
         // so we don't execute the following when the host is running
         // within an integration test
         builder.Host.UseSerilog(CdpLogging.Configuration);
-    }
 
     builder.Services.AddBasicAuthentication();
     // This adds default rate limiter, total request timeout, retries, circuit breaker and timeout per attempt
@@ -144,10 +142,9 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
     {
         var traceHeader = builder.Configuration.GetValue<string>("TraceHeader");
         if (!string.IsNullOrWhiteSpace(traceHeader))
-        {
             options.Headers.Add(traceHeader);
-        }
     });
+    builder.Services.AddOptions<AclOptions>().BindConfiguration("Acl").ValidateOptions();
     builder.Services.AddOptions<BtmsOptions>().BindConfiguration("Btms").ValidateOptions(!generatingOpenApiFromCli);
     builder.Services.AddJsonApiClient(
         (sp, options) =>

--- a/src/Api/Properties/launchSettings.json
+++ b/src/Api/Properties/launchSettings.json
@@ -7,7 +7,9 @@
       "applicationUrl": "http://localhost:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "ENVIRONMENT": "Local"
+        "ENVIRONMENT": "Local",
+        "AclOptions__Clients__LocalDev__Bcps__0": "bcp1",
+        "AclOptions__Clients__LocalDev__Bcps__1": "bcp2"
       }
     }
   }

--- a/src/Api/Properties/launchSettings.json
+++ b/src/Api/Properties/launchSettings.json
@@ -7,9 +7,7 @@
       "applicationUrl": "http://localhost:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "ENVIRONMENT": "Local",
-        "AclOptions__Clients__LocalDev__Bcps__0": "bcp1",
-        "AclOptions__Clients__LocalDev__Bcps__1": "bcp2"
+        "ENVIRONMENT": "Local"
       }
     }
   }

--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -22,6 +22,16 @@
       }
     ]
   },
+  "AclOptions": {
+    "Clients": {
+      "LocalDev": {
+        "Bcps": [
+          "bcp1",
+          "bcp2"
+        ]
+      }
+    }
+  },
   "BasicAuth": {
     "Enabled": false
   },

--- a/src/Api/appsettings.IntegrationTests.json
+++ b/src/Api/appsettings.IntegrationTests.json
@@ -8,5 +8,15 @@
   },
   "OpenApi": {
     "Host": "integration-test-host"
+  },
+  "Acl": {
+    "Clients": {
+      "pha": {
+        "Bcps": [
+          "bcp1",
+          "bcp2"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
A client only has access to certain BCPs.

This identifies the client set by config from environment variables and adds the BCP claims to the AuthenticationTicket, which can be later used to authorise requests.