### PR TITLE
PHAIN-104: Disable stub for test

### DIFF
--- a/src/Api/appsettings.cdp.test.json
+++ b/src/Api/appsettings.cdp.test.json
@@ -1,8 +1,5 @@
 {
   "Btms": {
     "BaseUrl": "http://localhost:8090"
-  },
-  "BtmsStub": {
-    "Enabled": true
   }
 }


### PR DESCRIPTION
We are changing to use the stub service rather than the hosted version.