### PR TITLE
PHAIN-42: Scan container for vulnerabilities

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -24,8 +24,15 @@ jobs:
           dotnet-version: |
             9.0
       - run: dotnet test
-      - name: Docker
-        uses: DEFRA/cdp-build-action/check-pr@main
+      - name: Check Dockerfile Builds
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          tags: pha-import-notifications:latest
+      - name: Check with Trivy
+        run: docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image pha-import-notifications:latest --ignore-unfixed
   sonarcloud-scan:
     name: CDP SonarCloud Scan
     uses: ./.github/workflows/sonarcloud.yml


### PR DESCRIPTION
This adds Trivy as part of the build checks to scan a container for vulnerabilities.