### PR TITLE
PHAIN-42: Remove basic auth rule exemption

### DIFF
--- a/.vacuum.yml
+++ b/.vacuum.yml
@@ -15,5 +15,3 @@ rules:
   # We may implement rate limiting but currently do not have it
   # https://quobix.com/vacuum/rules/owasp/owasp-rate-limit/
   owasp-rate-limit: false
-  # We're temporarily using Basic Auth
-  owasp-no-http-basic: false


### PR DESCRIPTION
We are no longer using basic auth.