### PR TITLE
Update latest BTMS schema to pull in UpdatedEntity field

### DIFF
--- a/src/Api/Endpoints/ImportNotifications/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/ImportNotifications/EndpointRouteBuilderExtensions.cs
@@ -60,7 +60,7 @@ public static class EndpointRouteBuilderExtensions
         );
         var updated = notifications.Select(x => new UpdatedImportNotification
         {
-            Updated = x.Updated,
+            Updated = x.UpdatedEntity,
             ReferenceNumber = x.ReferenceNumber,
             Links = new UpdatedImportNotificationLinks
             {

--- a/src/Api/Endpoints/ImportNotifications/UpdatedImportNotification.cs
+++ b/src/Api/Endpoints/ImportNotifications/UpdatedImportNotification.cs
@@ -5,7 +5,7 @@ namespace Defra.PhaImportNotifications.Api.Endpoints.ImportNotifications;
 
 internal sealed class UpdatedImportNotification
 {
-    [Description("Date last updated. Format is ISO 8601-1:2019")]
+    [Description("Date last updated or when related data was last updated. Format is ISO 8601-1:2019")]
     [Required]
     public required DateTime Updated { get; init; }
 

--- a/src/Api/Services/Btms/BtmsService.cs
+++ b/src/Api/Services/Btms/BtmsService.cs
@@ -22,11 +22,11 @@ public class BtmsService(IJsonApiClient jsonApiClient, IOptions<BtmsOptions> btm
                 new AnyExpression("_PointOfEntry", bcp),
                 new AnyExpression("importNotificationType", Enum.GetNames<ImportNotificationTypeEnum>()),
                 new NotExpression(new ComparisonExpression(ComparisonOperator.Equals, "status", "Draft")),
-                new ComparisonExpression(ComparisonOperator.GreaterOrEqual, "updated", from.ToString("O")),
-                new ComparisonExpression(ComparisonOperator.LessThan, "updated", to.ToString("O")),
+                new ComparisonExpression(ComparisonOperator.GreaterOrEqual, "updatedEntity", from.ToString("O")),
+                new ComparisonExpression(ComparisonOperator.LessThan, "updatedEntity", to.ToString("O")),
             ]
         );
-        var fields = new[] { new FieldExpression("import-notifications", ["updated", "referenceNumber"]) };
+        var fields = new[] { new FieldExpression("import-notifications", ["updatedEntity", "referenceNumber"]) };
 
         var document = await jsonApiClient.Get(
             new RequestUri("api/import-notifications", filter, fields, btmsOptions.Value.PageSize),

--- a/src/Contracts/AuditContext.g.cs
+++ b/src/Contracts/AuditContext.g.cs
@@ -1,0 +1,8 @@
+#nullable enable
+using System.Text.Json.Serialization;
+using System.ComponentModel;
+
+namespace Defra.PhaImportNotifications.Contracts;
+public partial record AuditContext
+{
+}

--- a/src/Contracts/AuditEntry.g.cs
+++ b/src/Contracts/AuditEntry.g.cs
@@ -27,5 +27,5 @@ public partial record AuditEntry
     public List<AuditDiffEntry>? Diff { get; init; }
 
     [JsonPropertyName("context")]
-    public DecisionContext? Context { get; init; }
+    public AuditContext? Context { get; init; }
 }

--- a/src/Contracts/DecisionImportNotifications.g.cs
+++ b/src/Contracts/DecisionImportNotifications.g.cs
@@ -17,6 +17,9 @@ public partial record DecisionImportNotifications
     [JsonPropertyName("updated")]
     public required DateTime Updated { get; init; }
 
+    [JsonPropertyName("updatedEntity")]
+    public required DateTime UpdatedEntity { get; init; }
+
     [JsonPropertyName("createdSource")]
     public required DateTime CreatedSource { get; init; }
 

--- a/src/Contracts/DecisionStatusEnum.g.cs
+++ b/src/Contracts/DecisionStatusEnum.g.cs
@@ -11,10 +11,6 @@ public enum DecisionStatusEnum
     NoAlvsDecisions,
     HasMultipleChedTypes,
     HasMultipleCheds,
-    AlvsClearanceRequestVersion1NotPresent,
-    AlvsClearanceRequestVersionsNotComplete,
-    AlvsDecisionVersion1NotPresent,
-    AlvsDecisionVersionsNotComplete,
     InvestigationNeeded,
     None
 }

--- a/src/Contracts/FinalState.g.cs
+++ b/src/Contracts/FinalState.g.cs
@@ -1,0 +1,11 @@
+namespace Defra.PhaImportNotifications.Contracts;
+public enum FinalState
+{
+    Cleared,
+    CancelledAfterArrival,
+    CancelledWhilePreLodged,
+    Destroyed,
+    Seized,
+    ReleasedToKingsWarehouse,
+    TransferredToMss
+}

--- a/src/Contracts/Finalisation.g.cs
+++ b/src/Contracts/Finalisation.g.cs
@@ -1,0 +1,13 @@
+#nullable enable
+using System.Text.Json.Serialization;
+using System.ComponentModel;
+
+namespace Defra.PhaImportNotifications.Contracts;
+public partial record Finalisation
+{
+    [JsonPropertyName("finalState")]
+    public required FinalState FinalState { get; init; }
+
+    [JsonPropertyName("manualAction")]
+    public required bool ManualAction { get; init; }
+}

--- a/src/Contracts/ImportNotification.g.cs
+++ b/src/Contracts/ImportNotification.g.cs
@@ -17,6 +17,10 @@ public partial record ImportNotification
     [Description("Date when the notification was created")]
     public required DateTime Created { get; init; }
 
+    [JsonPropertyName("updatedEntity")]
+    [Description("Date when the notification was updated or when related data was linked or updated")]
+    public required DateTime UpdatedEntity { get; init; }
+
     [JsonPropertyName("updated")]
     [Description("Date when the notification was last updated")]
     public required DateTime Updated { get; init; }

--- a/src/Contracts/ImportNotificationUpdate.cs
+++ b/src/Contracts/ImportNotificationUpdate.cs
@@ -2,6 +2,6 @@ namespace Defra.PhaImportNotifications.Contracts;
 
 public class ImportNotificationUpdate
 {
-    public required DateTime Updated { get; init; }
+    public required DateTime UpdatedEntity { get; init; }
     public required string ReferenceNumber { get; init; }
 }

--- a/src/Contracts/Movement.g.cs
+++ b/src/Contracts/Movement.g.cs
@@ -35,6 +35,10 @@ public partial record Movement
     [Description("Date when the movement was created in ALVS")]
     public DateTime? CreatedSource { get; init; }
 
+    [JsonPropertyName("updated")]
+    [Description("Date when the movement was last updated")]
+    public required DateTime Updated { get; init; }
+
     [JsonPropertyName("entryReference")]
     public string? EntryReference { get; init; }
 
@@ -91,7 +95,16 @@ public partial record Movement
     [Description("Date when the movement was created")]
     public required DateTime Created { get; init; }
 
-    [JsonPropertyName("updated")]
-    [Description("Date when the movement was last updated")]
-    public required DateTime Updated { get; init; }
+    [JsonPropertyName("updatedEntity")]
+    [Description("Date when the movement was updated or when related data was linked or updated")]
+    public required DateTime UpdatedEntity { get; init; }
+
+    [JsonPropertyName("finalised")]
+    public DateTime? Finalised { get; init; }
+
+    [JsonPropertyName("finalisedSource")]
+    public DateTime? FinalisedSource { get; init; }
+
+    [JsonPropertyName("finalisation")]
+    public Finalisation? Finalisation { get; init; }
 }

--- a/src/Contracts/RelationshipDataItem.g.cs
+++ b/src/Contracts/RelationshipDataItem.g.cs
@@ -5,9 +5,6 @@ using System.ComponentModel;
 namespace Defra.PhaImportNotifications.Contracts;
 public partial record RelationshipDataItem
 {
-    [JsonPropertyName("matched")]
-    public bool? Matched { get; init; }
-
     [JsonPropertyName("type")]
     public string? Type { get; init; }
 

--- a/src/Contracts/SyncFinalisationsCommand.g.cs
+++ b/src/Contracts/SyncFinalisationsCommand.g.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Text.Json.Serialization;
+using System.ComponentModel;
+
+namespace Defra.PhaImportNotifications.Contracts;
+public partial record SyncFinalisationsCommand
+{
+    [JsonPropertyName("syncPeriod")]
+    public required SyncPeriod SyncPeriod { get; init; }
+
+    [JsonPropertyName("rootFolder")]
+    public string? RootFolder { get; init; }
+
+    [JsonPropertyName("jobId")]
+    public required string JobId { get; init; }
+
+    [JsonPropertyName("timespan")]
+    public string? Timespan { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("resource")]
+    public string? Resource { get; init; }
+}

--- a/src/Contracts/SyncPeriod.g.cs
+++ b/src/Contracts/SyncPeriod.g.cs
@@ -4,5 +4,6 @@ public enum SyncPeriod
     Today,
     LastMonth,
     ThisMonth,
+    From202411,
     All
 }

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_WhenFound_ShouldSucceed.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_WhenFound_ShouldSucceed.verified.json
@@ -1,6 +1,7 @@
 ﻿{
   "createdSource": "2024-12-04T13:24:39.611Z",
   "created": "0001-01-01T00:00:00Z",
+  "updatedEntity": "2025-01-17T16:38:47.171Z",
   "updated": "2025-01-17T16:37:47.171Z",
   "commoditiesSummary": {
     "gmsDeclarationAccepted": null,

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetUpdatedTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetUpdatedTests.cs
@@ -41,7 +41,7 @@ public class GetUpdatedTests(ApiWebApplicationFactory factory, ITestOutputHelper
                     fixture
                         .Build<ImportNotificationUpdate>()
                         .With(x => x.ReferenceNumber, ChedReferenceNumbers.ChedA)
-                        .With(x => x.Updated, new DateTime(2024, 11, 29, 23, 59, 59, DateTimeKind.Utc))
+                        .With(x => x.UpdatedEntity, new DateTime(2024, 11, 29, 23, 59, 59, DateTimeKind.Utc))
                         .Create(),
                 }
             );

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -2028,7 +2028,8 @@
       "ImportNotificationResponse": {
         "required": [
           "created",
-          "updated"
+          "updated",
+          "updatedEntity"
         ],
         "type": "object",
         "properties": {
@@ -2055,6 +2056,11 @@
           "created": {
             "type": "string",
             "description": "Date when the notification was created",
+            "format": "date-time"
+          },
+          "updatedEntity": {
+            "type": "string",
+            "description": "Date when the notification was updated or when related data was linked or updated",
             "format": "date-time"
           },
           "updated": {
@@ -3781,7 +3787,7 @@
         "properties": {
           "updated": {
             "type": "string",
-            "description": "Date last updated. Format is ISO 8601-1:2019",
+            "description": "Date last updated or when related data was last updated. Format is ISO 8601-1:2019",
             "format": "date-time"
           },
           "referenceNumber": {

--- a/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotificationUpdates_WhenOk_ShouldSucceed.verified.txt
+++ b/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotificationUpdates_WhenOk_ShouldSucceed.verified.txt
@@ -1,42 +1,42 @@
 ﻿[
   {
-    Updated: 2024-12-11 08:12:58.792 Utc,
+    UpdatedEntity: 2024-12-11 08:12:58.792 Utc,
     ReferenceNumber: CHEDA.GB.2024.4792831
   },
   {
-    Updated: 2024-12-11 08:12:59.114 Utc,
+    UpdatedEntity: 2024-12-11 08:12:59.114 Utc,
     ReferenceNumber: CHEDD.GB.2024.5019877
   },
   {
-    Updated: 2024-12-11 08:12:59.741 Utc,
+    UpdatedEntity: 2024-12-11 08:12:59.741 Utc,
     ReferenceNumber: CHEDP.GB.2024.4144842
   },
   {
-    Updated: 2024-12-11 08:12:59.947 Utc,
+    UpdatedEntity: 2024-12-11 08:12:59.947 Utc,
     ReferenceNumber: CHEDPP.GB.2024.3726460
   },
   {
-    Updated: 2024-12-11 08:13:00.108 Utc,
+    UpdatedEntity: 2024-12-11 08:13:00.108 Utc,
     ReferenceNumber: CHEDA.GB.2024.5129502
   },
   {
-    Updated: 2024-12-11 08:13:00.203 Utc,
+    UpdatedEntity: 2024-12-11 08:13:00.203 Utc,
     ReferenceNumber: CHEDA.GB.2024.011113000003
   },
   {
-    Updated: 2024-12-11 08:13:01.234 Utc,
+    UpdatedEntity: 2024-12-11 08:13:01.234 Utc,
     ReferenceNumber: CHEDA.GB.2024.011114000001
   },
   {
-    Updated: 2024-12-11 08:13:01.546 Utc,
+    UpdatedEntity: 2024-12-11 08:13:01.546 Utc,
     ReferenceNumber: CHEDA.GB.2024.011114000002
   },
   {
-    Updated: 2024-12-11 08:13:01.831 Utc,
+    UpdatedEntity: 2024-12-11 08:13:01.831 Utc,
     ReferenceNumber: CHEDA.GB.2024.011114000003
   },
   {
-    Updated: 2024-12-11 08:13:02.953 Utc,
+    UpdatedEntity: 2024-12-11 08:13:02.953 Utc,
     ReferenceNumber: CHEDA.GB.2024.011115000001
   }
 ]

--- a/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDA.GB.2024.4792831.verified.txt
+++ b/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDA.GB.2024.4792831.verified.txt
@@ -4,6 +4,7 @@
   _Etag: null,
   CreatedSource: 2024-12-04 13:24:39.611 Utc,
   Created: 0001-01-01 Utc,
+  UpdatedEntity: 2025-01-17 16:38:47.171 Utc,
   Updated: 2025-01-17 16:37:47.171 Utc,
   AuditEntries: null,
   Relationships: null,

--- a/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.4144842.verified.txt
+++ b/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.4144842.verified.txt
@@ -4,6 +4,7 @@
   _Etag: null,
   CreatedSource: 2024-05-02 12:19:47.06 Utc,
   Created: 2025-01-17 16:45:41.165 Utc,
+  UpdatedEntity: 2025-01-17 16:46:41.165 Utc,
   Updated: 2025-01-17 16:45:41.165 Utc,
   AuditEntries: null,
   Relationships: null,

--- a/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDPP.GB.2024.3726460.verified.txt
+++ b/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDPP.GB.2024.3726460.verified.txt
@@ -4,6 +4,7 @@
   _Etag: null,
   CreatedSource: 2024-12-04 06:00:04.77 Utc,
   Created: 2025-01-17 17:01:03.247 Utc,
+  UpdatedEntity: 2025-01-17 17:02:03.247 Utc,
   Updated: 2025-01-17 17:01:03.247 Utc,
   AuditEntries: null,
   Relationships: null,

--- a/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WithMovements_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDA.GB.2024.5129502.verified.txt
+++ b/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WithMovements_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDA.GB.2024.5129502.verified.txt
@@ -414,6 +414,7 @@
   _Etag: null,
   CreatedSource: 2024-12-04 09:00:39.511 Utc,
   Created: 0001-01-01 Utc,
+  UpdatedEntity: 2025-01-17 16:39:33.739 Utc,
   Updated: 2025-01-17 16:38:33.739 Utc,
   AuditEntries: null,
   Relationships: null,

--- a/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WithMovements_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5019877.verified.txt
+++ b/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WithMovements_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5019877.verified.txt
@@ -100,6 +100,7 @@
   _Etag: null,
   CreatedSource: 2024-12-04 16:14:19.067 Utc,
   Created: 0001-01-01 Utc,
+  UpdatedEntity: 2025-01-17 17:00:25.037 Utc,
   Updated: 2025-01-17 16:59:25.037 Utc,
   AuditEntries: null,
   Relationships: null,

--- a/tests/Api.Tests/Services/Btms/BtmsServiceTests.cs
+++ b/tests/Api.Tests/Services/Btms/BtmsServiceTests.cs
@@ -59,11 +59,11 @@ public class BtmsServiceTests : WireMockTestBase<WireMockContextQueryParameterNo
                         + "any(_PointOfEntry,'bcp1','bcp2'),"
                         + "any(importNotificationType,'Cveda','Cvedp','Chedpp','Ced'),"
                         + "not(equals(status,'Draft')),"
-                        + "greaterOrEqual(updated,'2024-12-12T13:10:30.0000000Z'),"
-                        + "lessThan(updated,'2024-12-12T13:40:30.0000000Z')"
+                        + "greaterOrEqual(updatedEntity,'2024-12-12T13:10:30.0000000Z'),"
+                        + "lessThan(updatedEntity,'2024-12-12T13:40:30.0000000Z')"
                         + ")"
                 )
-                .WithJsonApiParam("fields[import-notifications]", "updated,referenceNumber")
+                .WithJsonApiParam("fields[import-notifications]", "updatedEntity,referenceNumber")
                 .WithJsonApiParam("page[size]", "100")
         );
 

--- a/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDA.GB.2024.4792831.json
+++ b/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDA.GB.2024.4792831.json
@@ -9,6 +9,7 @@
       "createdSource": "2024-12-04T13:24:39.611Z",
       "created": "0001-01-01T00:00:00Z",
       "updated": "2025-01-17T16:37:47.171Z",
+      "updatedEntity": "2025-01-17T16:38:47.171Z",
       "stringId": "CHEDA.GB.2024.4792831",
       "auditEntries": [
         {

--- a/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDA.GB.2024.5129502.json
+++ b/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDA.GB.2024.5129502.json
@@ -9,6 +9,7 @@
       "createdSource": "2024-12-04T09:00:39.511Z",
       "created": "0001-01-01T00:00:00Z",
       "updated": "2025-01-17T16:38:33.739Z",
+      "updatedEntity": "2025-01-17T16:39:33.739Z",
       "stringId": "CHEDA.GB.2024.5129502",
       "auditEntries": [
         {

--- a/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDA.GB.2024.5149729.json
+++ b/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDA.GB.2024.5149729.json
@@ -9,6 +9,7 @@
       "createdSource": "2024-12-05T22:00:07.964Z",
       "created": "2025-01-17T16:44:12.997Z",
       "updated": "2025-01-17T16:46:11.714Z",
+      "updatedEntity": "2025-01-17T16:47:11.714Z",
       "stringId": "CHEDA.GB.2024.5149729",
       "auditEntries": [
         {

--- a/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDD.GB.2024.5019877.json
+++ b/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDD.GB.2024.5019877.json
@@ -9,6 +9,7 @@
       "createdSource": "2024-12-04T16:14:19.067Z",
       "created": "0001-01-01T00:00:00Z",
       "updated": "2025-01-17T16:59:25.037Z",
+      "updatedEntity": "2025-01-17T17:00:25.037Z",
       "stringId": "CHEDD.GB.2024.5019877",
       "auditEntries": [
         {

--- a/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDP.GB.2024.4144842.json
+++ b/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDP.GB.2024.4144842.json
@@ -9,6 +9,7 @@
       "createdSource": "2024-05-02T12:19:47.06Z",
       "created": "2025-01-17T16:45:41.165Z",
       "updated": "2025-01-17T16:45:41.165Z",
+      "updatedEntity": "2025-01-17T16:46:41.165Z",
       "stringId": "CHEDP.GB.2024.4144842",
       "auditEntries": [
         {

--- a/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDPP.GB.2024.3726460.json
+++ b/tests/BtmsStub/Scenarios/btms-import-notification-single-CHEDPP.GB.2024.3726460.json
@@ -9,6 +9,7 @@
       "createdSource": "2024-12-04T06:00:04.77Z",
       "created": "2025-01-17T17:01:03.247Z",
       "updated": "2025-01-17T17:01:03.247Z",
+      "updatedEntity": "2025-01-17T17:02:03.247Z",
       "stringId": "CHEDPP.GB.2024.3726460",
       "auditEntries": [
         {

--- a/tests/BtmsStub/Scenarios/btms-import-notification-updates.json
+++ b/tests/BtmsStub/Scenarios/btms-import-notification-updates.json
@@ -8,7 +8,7 @@
       "type": "import-notifications",
       "id": "CHEDA.GB.2024.4792831",
       "attributes": {
-        "updated": "2024-12-11T08:12:58.792Z",
+        "updatedEntity": "2024-12-11T08:12:58.792Z",
         "referenceNumber": "CHEDA.GB.2024.4792831"
       },
       "links": {
@@ -19,7 +19,7 @@
       "type": "import-notifications",
       "id": "CHEDD.GB.2024.5019877",
       "attributes": {
-        "updated": "2024-12-11T08:12:59.114Z",
+        "updatedEntity": "2024-12-11T08:12:59.114Z",
         "referenceNumber": "CHEDD.GB.2024.5019877"
       },
       "links": {
@@ -30,7 +30,7 @@
       "type": "import-notifications",
       "id": "CHEDP.GB.2024.4144842",
       "attributes": {
-        "updated": "2024-12-11T08:12:59.741Z",
+        "updatedEntity": "2024-12-11T08:12:59.741Z",
         "referenceNumber": "CHEDP.GB.2024.4144842"
       },
       "links": {
@@ -41,7 +41,7 @@
       "type": "import-notifications",
       "id": "CHEDPP.GB.2024.3726460",
       "attributes": {
-        "updated": "2024-12-11T08:12:59.947Z",
+        "updatedEntity": "2024-12-11T08:12:59.947Z",
         "referenceNumber": "CHEDPP.GB.2024.3726460"
       },
       "links": {
@@ -52,7 +52,7 @@
       "type": "import-notifications",
       "id": "CHEDA.GB.2024.5129502",
       "attributes": {
-        "updated": "2024-12-11T08:13:00.108Z",
+        "updatedEntity": "2024-12-11T08:13:00.108Z",
         "referenceNumber": "CHEDA.GB.2024.5129502"
       },
       "links": {
@@ -63,7 +63,7 @@
       "type": "import-notifications",
       "id": "CHEDA.GB.2024.011113000003",
       "attributes": {
-        "updated": "2024-12-11T08:13:00.203Z",
+        "updatedEntity": "2024-12-11T08:13:00.203Z",
         "referenceNumber": "CHEDA.GB.2024.011113000003"
       },
       "links": {
@@ -74,7 +74,7 @@
       "type": "import-notifications",
       "id": "CHEDA.GB.2024.011114000001",
       "attributes": {
-        "updated": "2024-12-11T08:13:01.234Z",
+        "updatedEntity": "2024-12-11T08:13:01.234Z",
         "referenceNumber": "CHEDA.GB.2024.011114000001"
       },
       "links": {
@@ -85,7 +85,7 @@
       "type": "import-notifications",
       "id": "CHEDA.GB.2024.011114000002",
       "attributes": {
-        "updated": "2024-12-11T08:13:01.546Z",
+        "updatedEntity": "2024-12-11T08:13:01.546Z",
         "referenceNumber": "CHEDA.GB.2024.011114000002"
       },
       "links": {
@@ -96,7 +96,7 @@
       "type": "import-notifications",
       "id": "CHEDA.GB.2024.011114000003",
       "attributes": {
-        "updated": "2024-12-11T08:13:01.831Z",
+        "updatedEntity": "2024-12-11T08:13:01.831Z",
         "referenceNumber": "CHEDA.GB.2024.011114000003"
       },
       "links": {
@@ -107,7 +107,7 @@
       "type": "import-notifications",
       "id": "CHEDA.GB.2024.011115000001",
       "attributes": {
-        "updated": "2024-12-11T08:13:02.953Z",
+        "updatedEntity": "2024-12-11T08:13:02.953Z",
         "referenceNumber": "CHEDA.GB.2024.011115000001"
       },
       "links": {

--- a/tests/BtmsStub/Scenarios/btms-movement-single-24GBC1IQDD278IZAR8.json
+++ b/tests/BtmsStub/Scenarios/btms-movement-single-24GBC1IQDD278IZAR8.json
@@ -373,7 +373,8 @@
       ],
       "localId": null,
       "created": "2025-01-17T16:32:45.811Z",
-      "updated": "2025-01-17T18:24:31.37Z"
+      "updated": "2025-01-17T18:24:31.37Z",
+      "updatedEntity": "2025-01-17T18:25:31.37Z"
     },
     "relationships": {
       "notifications": {

--- a/tests/BtmsStub/Scenarios/btms-movement-single-24GBCND8RONCFGAAR3.json
+++ b/tests/BtmsStub/Scenarios/btms-movement-single-24GBCND8RONCFGAAR3.json
@@ -875,7 +875,8 @@
       ],
       "localId": null,
       "created": "2025-01-17T16:32:47.049Z",
-      "updated": "2025-01-17T18:24:31.865Z"
+      "updated": "2025-01-17T18:24:31.865Z",
+      "updatedEntity": "2025-01-17T18:25:31.865Z"
     },
     "relationships": {
       "notifications": {

--- a/tests/BtmsStub/Scenarios/btms-movement-single-24GBE0XBAS7Z0J5AR0.json
+++ b/tests/BtmsStub/Scenarios/btms-movement-single-24GBE0XBAS7Z0J5AR0.json
@@ -386,7 +386,8 @@
       ],
       "localId": null,
       "created": "2025-01-17T16:59:24.711Z",
-      "updated": "2025-01-17T18:53:14.37Z"
+      "updated": "2025-01-17T18:53:14.37Z",
+      "updatedEntity": "2025-01-17T18:54:14.37Z"
     },
     "relationships": {
       "notifications": {

--- a/tools/SchemaToCSharp/Meta.cs
+++ b/tools/SchemaToCSharp/Meta.cs
@@ -14,6 +14,10 @@ internal static class Meta
                 { "Updated", "Date when the notification was last updated" },
                 { "CreatedSource", "Date when the notification was created in IPAFFS" },
                 { "UpdatedSource", "Date when the notification was last updated in IPAFFS" },
+                {
+                    "UpdatedEntity",
+                    "Date when the notification was updated or when related data was linked or updated"
+                },
             }
         },
         {
@@ -24,6 +28,7 @@ internal static class Meta
                 { "Updated", "Date when the movement was last updated" },
                 { "CreatedSource", "Date when the movement was created in ALVS" },
                 { "UpdatedSource", "Date when the movement was last updated in ALVS" },
+                { "UpdatedEntity", "Date when the movement was updated or when related data was linked or updated" },
             }
         },
     };

--- a/tools/SchemaToCSharp/btms-public-openapi-v0.1.json
+++ b/tools/SchemaToCSharp/btms-public-openapi-v0.1.json
@@ -12,6 +12,22 @@
         ],
         "parameters": [
           {
+            "name": "dateFrom",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
             "name": "chartsToRender",
             "in": "query",
             "required": true,
@@ -41,19 +57,11 @@
             }
           },
           {
-            "name": "dateFrom",
+            "name": "finalisedOnly",
             "in": "query",
             "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "dateTo",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
+              "type": "boolean",
+              "default": true
             }
           }
         ],
@@ -93,6 +101,22 @@
         ],
         "parameters": [
           {
+            "name": "dateFrom",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
             "name": "chedType",
             "in": "query",
             "required": true,
@@ -111,19 +135,11 @@
             }
           },
           {
-            "name": "dateFrom",
+            "name": "finalisedOnly",
             "in": "query",
             "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "dateTo",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
+              "type": "boolean",
+              "default": true
             }
           }
         ],
@@ -263,6 +279,7 @@
                 "Today",
                 "LastMonth",
                 "ThisMonth",
+                "From202411",
                 "All"
               ],
               "allOf": [
@@ -304,6 +321,18 @@
         }
       }
     },
+    "/mgmt/server/forcegc": {
+      "get": {
+        "tags": [
+          "ManagementEndpoints"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "tags": [
@@ -331,6 +360,7 @@
                 "Today",
                 "LastMonth",
                 "ThisMonth",
+                "From202411",
                 "All"
               ],
               "allOf": [
@@ -387,6 +417,7 @@
                 "Today",
                 "LastMonth",
                 "ThisMonth",
+                "From202411",
                 "All"
               ],
               "allOf": [
@@ -428,54 +459,6 @@
         }
       }
     },
-    "/sync/generate-download": {
-      "post": {
-        "tags": [
-          "SyncEndpoints"
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/DownloadCommand"
-                  }
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/sync/download/{id}": {
-      "get": {
-        "tags": [
-          "SyncEndpoints"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
     "/sync/gmrs": {
       "get": {
         "tags": [
@@ -491,6 +474,7 @@
                 "Today",
                 "LastMonth",
                 "ThisMonth",
+                "From202411",
                 "All"
               ],
               "allOf": [
@@ -547,6 +531,7 @@
                 "Today",
                 "LastMonth",
                 "ThisMonth",
+                "From202411",
                 "All"
               ],
               "allOf": [
@@ -581,6 +566,111 @@
           },
           "required": true
         },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/sync/finalisations": {
+      "get": {
+        "tags": [
+          "SyncEndpoints"
+        ],
+        "parameters": [
+          {
+            "name": "syncPeriod",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "enum": [
+                "Today",
+                "LastMonth",
+                "ThisMonth",
+                "From202411",
+                "All"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/SyncPeriod"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "SyncEndpoints"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SyncFinalisationsCommand"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/sync/generate-download": {
+      "post": {
+        "tags": [
+          "SyncEndpoints"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DownloadCommand"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/sync/download/{id}": {
+      "get": {
+        "tags": [
+          "SyncEndpoints"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -1071,6 +1161,10 @@
         },
         "additionalProperties": false
       },
+      "AuditContext": {
+        "type": "object",
+        "additionalProperties": false
+      },
       "AuditDiffEntry": {
         "type": "object",
         "properties": {
@@ -1137,7 +1231,7 @@
           "context": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/DecisionContext"
+                "$ref": "#/components/schemas/AuditContext"
               }
             ],
             "nullable": true
@@ -2356,10 +2450,6 @@
               "NoAlvsDecisions",
               "HasMultipleChedTypes",
               "HasMultipleCheds",
-              "AlvsClearanceRequestVersion1NotPresent",
-              "AlvsClearanceRequestVersionsNotComplete",
-              "AlvsDecisionVersion1NotPresent",
-              "AlvsDecisionVersionsNotComplete",
               "InvestigationNeeded",
               "None"
             ],
@@ -2490,6 +2580,7 @@
           "createdSource",
           "id",
           "updated",
+          "updatedEntity",
           "updatedSource",
           "version"
         ],
@@ -2509,6 +2600,10 @@
             "format": "date-time"
           },
           "updated": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedEntity": {
             "type": "string",
             "format": "date-time"
           },
@@ -2628,10 +2723,6 @@
           "NoAlvsDecisions",
           "HasMultipleChedTypes",
           "HasMultipleCheds",
-          "AlvsClearanceRequestVersion1NotPresent",
-          "AlvsClearanceRequestVersionsNotComplete",
-          "AlvsDecisionVersion1NotPresent",
-          "AlvsDecisionVersionsNotComplete",
           "InvestigationNeeded",
           "None"
         ],
@@ -2730,6 +2821,7 @@
               "Today",
               "LastMonth",
               "ThisMonth",
+              "From202411",
               "All"
             ],
             "allOf": [
@@ -2966,6 +3058,47 @@
         ],
         "type": "string"
       },
+      "FinalState": {
+        "enum": [
+          "Cleared",
+          "CancelledAfterArrival",
+          "CancelledWhilePreLodged",
+          "Destroyed",
+          "Seized",
+          "ReleasedToKingsWarehouse",
+          "TransferredToMss"
+        ],
+        "type": "string"
+      },
+      "Finalisation": {
+        "required": [
+          "finalState",
+          "manualAction"
+        ],
+        "type": "object",
+        "properties": {
+          "finalState": {
+            "enum": [
+              "Cleared",
+              "CancelledAfterArrival",
+              "CancelledWhilePreLodged",
+              "Destroyed",
+              "Seized",
+              "ReleasedToKingsWarehouse",
+              "TransferredToMss"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FinalState"
+              }
+            ]
+          },
+          "manualAction": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
       "Header": {
         "type": "object",
         "properties": {
@@ -3143,6 +3276,10 @@
             "nullable": true
           },
           "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedEntity": {
             "type": "string",
             "format": "date-time"
           },
@@ -3913,6 +4050,10 @@
             "format": "date-time",
             "nullable": true
           },
+          "updated": {
+            "type": "string",
+            "format": "date-time"
+          },
           "entryReference": {
             "type": "string",
             "nullable": true
@@ -3993,9 +4134,27 @@
             "type": "string",
             "format": "date-time"
           },
-          "updated": {
+          "updatedEntity": {
             "type": "string",
             "format": "date-time"
+          },
+          "finalised": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "finalisedSource": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "finalisation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Finalisation"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -5148,10 +5307,6 @@
       "RelationshipDataItem": {
         "type": "object",
         "properties": {
-          "matched": {
-            "type": "boolean",
-            "nullable": true
-          },
           "type": {
             "type": "string",
             "nullable": true
@@ -5478,6 +5633,7 @@
               "Today",
               "LastMonth",
               "ThisMonth",
+              "From202411",
               "All"
             ],
             "allOf": [
@@ -5520,6 +5676,50 @@
               "Today",
               "LastMonth",
               "ThisMonth",
+              "From202411",
+              "All"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SyncPeriod"
+              }
+            ]
+          },
+          "rootFolder": {
+            "type": "string",
+            "nullable": true
+          },
+          "jobId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "timespan": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "resource": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SyncFinalisationsCommand": {
+        "type": "object",
+        "properties": {
+          "syncPeriod": {
+            "enum": [
+              "Today",
+              "LastMonth",
+              "ThisMonth",
+              "From202411",
               "All"
             ],
             "allOf": [
@@ -5562,6 +5762,7 @@
               "Today",
               "LastMonth",
               "ThisMonth",
+              "From202411",
               "All"
             ],
             "allOf": [
@@ -5604,6 +5805,7 @@
               "Today",
               "LastMonth",
               "ThisMonth",
+              "From202411",
               "All"
             ],
             "allOf": [
@@ -5657,6 +5859,7 @@
           "Today",
           "LastMonth",
           "ThisMonth",
+          "From202411",
           "All"
         ],
         "type": "string"


### PR DESCRIPTION
This PR changes the field we filter on from BTMS. `UpdatedEntity` is now the field to use as it will denote when the resource has changed or if related data is linked or has changed itself.

I have kept our PHA contract the same so when asking for updates it will return the list of notifications with an `Updated` date. This date will not be the `UpdatedEntity` field. I have updated docs to express this and both the `Updated` and `UpdatedEntity` field will be returned when requesting the notification directly, therefore this should be adequate.