### PR TITLE
PHAIN-133: Add instructions for querying a deployed BTMS instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ It is possible to configure the PHA API to query a deployed BTMS instance.
 Fill out the [BtmsOptions](./src/Api/Configuration/BtmsOptions.cs) configuration to point at a BTMS instance and then
 perform a request to the PHA API whilst connected to the VPN.
 
+The `Username` and `Password` are Basic Auth credentials.
+
 ## Testing
 
 The unit and integration tests can either be run via your IDE or alternatively with `dotnet test .`

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ At the moment this is a manual process:
 5. Run `make update-btms-schema` in the root of the repository
 6. Observe any changes that have been made and commit them
 
+## Development
+
+It is possible to configure the PHA API to query a deployed BTMS instance.
+
+Fill out the [BtmsOptions](./src/Api/Configuration/BtmsOptions.cs) configuration to point at a BTMS instance and then
+perform a request to the PHA API whilst connected to the VPN.
+
 ## Testing
 
 The unit and integration tests can either be run via your IDE or alternatively with `dotnet test .`


### PR DESCRIPTION
This change adds some instructions to the README for using a real BTMS instance to develop against.