### PR TITLE
Update schema based on build https://github.com/DEFRA/btms-backend/actions/runs/13503451073

### DIFF
--- a/src/Contracts/AccompanyingDocument.g.cs
+++ b/src/Contracts/AccompanyingDocument.g.cs
@@ -15,7 +15,7 @@ public partial record AccompanyingDocument
 
     [JsonPropertyName("documentIssuedOn")]
     [Description("Additional document issue date")]
-    public DateTime? DocumentIssuedOn { get; init; }
+    public DateOnly? DocumentIssuedOn { get; init; }
 
     [JsonPropertyName("attachmentId")]
     [Description("The UUID used for the uploaded file in blob storage")]

--- a/src/Contracts/BusinessDecisionStatusEnum.g.cs
+++ b/src/Contracts/BusinessDecisionStatusEnum.g.cs
@@ -1,0 +1,17 @@
+namespace Defra.PhaImportNotifications.Contracts;
+public enum BusinessDecisionStatusEnum
+{
+    CancelledOrDestroyed,
+    ManualReleases,
+    AlvsDataErrorDecision,
+    BtmsDataErrorDecision,
+    MatchComplete,
+    MatchGroup,
+    AlvsHoldBtmsNotHeld,
+    AlvsNotHeldBtmsHold,
+    AlvsReleaseBtmsNotReleased,
+    AlvsNotReleasedBtmsReleased,
+    AlvsRefuseBtmsNotRefused,
+    AlvsNotRefusedBtmsRefused,
+    AnythingElse
+}

--- a/src/Contracts/CatchCertificateDetails.g.cs
+++ b/src/Contracts/CatchCertificateDetails.g.cs
@@ -15,7 +15,7 @@ public partial record CatchCertificateDetails
 
     [JsonPropertyName("issuedOn")]
     [Description("Catch certificate date of issue")]
-    public DateTime? IssuedOn { get; init; }
+    public DateOnly? IssuedOn { get; init; }
 
     [JsonPropertyName("flagState")]
     [Description("Catch certificate flag state of catching vessel(s)")]

--- a/src/Contracts/Customs.g.cs
+++ b/src/Contracts/Customs.g.cs
@@ -1,0 +1,10 @@
+#nullable enable
+using System.Text.Json.Serialization;
+using System.ComponentModel;
+
+namespace Defra.PhaImportNotifications.Contracts;
+public partial record Customs
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+}

--- a/src/Contracts/Decision.g.cs
+++ b/src/Contracts/Decision.g.cs
@@ -51,7 +51,7 @@ public partial record Decision
 
     [JsonPropertyName("notAcceptableActionByDate")]
     [Description("Filled when consignmentAcceptable is set to false")]
-    public string? NotAcceptableActionByDate { get; init; }
+    public DateOnly? NotAcceptableActionByDate { get; init; }
 
     [JsonPropertyName("chedppNotAcceptableReasons")]
     [Description("List of details for individual chedpp not acceptable reasons")]

--- a/src/Contracts/DecisionStatusEnum.g.cs
+++ b/src/Contracts/DecisionStatusEnum.g.cs
@@ -16,6 +16,8 @@ public enum DecisionStatusEnum
     HasGenericDataErrors,
     HasMultipleChedTypes,
     HasMultipleCheds,
+    BtmsClearAlvsHold,
+    AlvsClearBtmsHold,
     InvestigationNeeded,
     None
 }

--- a/src/Contracts/Declarations.g.cs
+++ b/src/Contracts/Declarations.g.cs
@@ -1,0 +1,15 @@
+#nullable enable
+using System.Text.Json.Serialization;
+using System.ComponentModel;
+
+namespace Defra.PhaImportNotifications.Contracts;
+public partial record Declarations
+{
+    [JsonPropertyName("transits")]
+    [Description("A list of declaration ids.")]
+    public List<Transits>? Transits { get; init; }
+
+    [JsonPropertyName("customs")]
+    [Description("A list of declaration ids.")]
+    public List<Customs>? Customs { get; init; }
+}

--- a/src/Contracts/DetailsOnReExport.g.cs
+++ b/src/Contracts/DetailsOnReExport.g.cs
@@ -7,7 +7,7 @@ public partial record DetailsOnReExport
 {
     [JsonPropertyName("date")]
     [Description("Date of re-export")]
-    public DateTime? Date { get; init; }
+    public DateOnly? Date { get; init; }
 
     [JsonPropertyName("meansOfTransportNo")]
     [Description("Number of vehicle")]

--- a/src/Contracts/Gmr.g.cs
+++ b/src/Contracts/Gmr.g.cs
@@ -17,6 +17,9 @@ public partial record Gmr
     [JsonIgnore]
     public DateTime? UpdatedEntity { get; init; }
 
+    [JsonPropertyName("updated")]
+    public required DateTime Updated { get; init; }
+
     [JsonPropertyName("auditEntries")]
     [JsonIgnore]
     public List<AuditEntry>? AuditEntries { get; init; }
@@ -87,4 +90,7 @@ public partial record Gmr
 
     [JsonPropertyName("actualCrossing")]
     public ActualCrossing? ActualCrossing { get; init; }
+
+    [JsonPropertyName("declarations")]
+    public Declarations? Declarations { get; init; }
 }

--- a/src/Contracts/GmrRelationships.g.cs
+++ b/src/Contracts/GmrRelationships.g.cs
@@ -5,9 +5,6 @@ using System.ComponentModel;
 namespace Defra.PhaImportNotifications.Contracts;
 public partial record GmrRelationships
 {
-    [JsonPropertyName("transits")]
-    public TdmRelationshipObject? Transits { get; init; }
-
-    [JsonPropertyName("customs")]
-    public TdmRelationshipObject? Customs { get; init; }
+    [JsonPropertyName("importNotifications")]
+    public TdmRelationshipObject? ImportNotifications { get; init; }
 }

--- a/src/Contracts/LaboratoryTestResult.g.cs
+++ b/src/Contracts/LaboratoryTestResult.g.cs
@@ -11,7 +11,7 @@ public partial record LaboratoryTestResult
 
     [JsonPropertyName("releasedOn")]
     [Description("When it was released")]
-    public DateTime? ReleasedOn { get; init; }
+    public DateOnly? ReleasedOn { get; init; }
 
     [JsonPropertyName("laboratoryTestMethod")]
     [Description("Laboratory test method")]
@@ -27,5 +27,5 @@ public partial record LaboratoryTestResult
 
     [JsonPropertyName("labTestCreatedOn")]
     [Description("Date of lab test created in IPAFFS")]
-    public DateTime? LabTestCreatedOn { get; init; }
+    public DateOnly? LabTestCreatedOn { get; init; }
 }

--- a/src/Contracts/MovementStatus.g.cs
+++ b/src/Contracts/MovementStatus.g.cs
@@ -19,4 +19,7 @@ public partial record MovementStatus
 
     [JsonPropertyName("segment")]
     public MovementSegmentEnum? Segment { get; init; }
+
+    [JsonPropertyName("businessDecisionStatus")]
+    public required BusinessDecisionStatusEnum BusinessDecisionStatus { get; init; }
 }

--- a/src/Contracts/NotificationTdmRelationships.g.cs
+++ b/src/Contracts/NotificationTdmRelationships.g.cs
@@ -7,4 +7,7 @@ public partial record NotificationTdmRelationships
 {
     [JsonPropertyName("movements")]
     public TdmRelationshipObject? Movements { get; init; }
+
+    [JsonPropertyName("gmrs")]
+    public TdmRelationshipObject? Gmrs { get; init; }
 }

--- a/src/Contracts/Purpose.g.cs
+++ b/src/Contracts/Purpose.g.cs
@@ -51,7 +51,7 @@ public partial record Purpose
 
     [JsonPropertyName("exitDate")]
     [Description("Exit date when import or admission")]
-    public string? ExitDate { get; init; }
+    public DateOnly? ExitDate { get; init; }
 
     [JsonPropertyName("finalBip")]
     [Description("Final Border Inspection Post")]

--- a/src/Contracts/Transits.g.cs
+++ b/src/Contracts/Transits.g.cs
@@ -1,0 +1,10 @@
+#nullable enable
+using System.Text.Json.Serialization;
+using System.ComponentModel;
+
+namespace Defra.PhaImportNotifications.Contracts;
+public partial record Transits
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+}

--- a/src/Contracts/VeterinaryInformation.g.cs
+++ b/src/Contracts/VeterinaryInformation.g.cs
@@ -19,7 +19,7 @@ public partial record VeterinaryInformation
 
     [JsonPropertyName("veterinaryDocumentIssuedOn")]
     [Description("Veterinary document issue date")]
-    public string? VeterinaryDocumentIssuedOn { get; init; }
+    public DateOnly? VeterinaryDocumentIssuedOn { get; init; }
 
     [JsonPropertyName("accompanyingDocumentNumbers")]
     [Description("Additional documents")]

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDA.GB.2024.5129502.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDA.GB.2024.5129502.verified.json
@@ -265,7 +265,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "34b41a1fd828b0f0cf66d3cd69645dbfadf2d49ef419878b2f78a51feabe16a1",
-          "documentIssuedOn": "2024-12-02T00:00:00",
+          "documentIssuedOn": "2024-12-02",
           "attachmentId": null,
           "attachmentFilename": null,
           "attachmentContentType": null,

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5019877.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5019877.verified.json
@@ -322,7 +322,7 @@
         {
           "documentType": "CommercialInvoice",
           "documentReference": "74cb5dd82f1447269211903e4783b359554696e1da0815ca82c8c727e1629a01",
-          "documentIssuedOn": "2024-10-05T00:00:00",
+          "documentIssuedOn": "2024-10-05",
           "attachmentId": "9923b835cf806587236e95327a9770fdee40fa2a5aacde9659fdd5cf470ae42f",
           "attachmentFilename": "52bd182b6da862683f80ecb199ef6bd7df122b7bd10fa49237074d7f17f544a8",
           "attachmentContentType": "application/pdf",
@@ -333,7 +333,7 @@
         {
           "documentType": "PackingList",
           "documentReference": "ec3a2a752d313b9d5ab28e466a1ce9f744e568a9e37a325f5df009b23e3be18a",
-          "documentIssuedOn": "2024-10-05T00:00:00",
+          "documentIssuedOn": "2024-10-05",
           "attachmentId": "29870dfbb0a6c9e8240a5eec213a37a864151c09789029af026c8f3fbfce309d",
           "attachmentFilename": "f2390b243437c0438ddb08461b6ba9a6d53e4c5ed6ba182c55f046c59da9c09c",
           "attachmentContentType": "application/pdf",
@@ -344,7 +344,7 @@
         {
           "documentType": "BillOfLading",
           "documentReference": "bc589386d680aea446d36754437a004051533f226538ea44250a6ed01ac43b3c",
-          "documentIssuedOn": "2024-10-08T00:00:00",
+          "documentIssuedOn": "2024-10-08",
           "attachmentId": "0caf0a657f485727dd7b60300433c804efbdd61fa1ea88984315e22c9d8c70b7",
           "attachmentFilename": "cc265ea11e510c568c8af2b97cf279f307fbe7a4ac6b7addaa592e22324ffcff",
           "attachmentContentType": "application/pdf",
@@ -355,7 +355,7 @@
         {
           "documentType": "PhytosanitaryCertificate",
           "documentReference": "13ec04773890d89598bb938c85674b73f8f1fd379c57ea2a19bb2ec516d71106",
-          "documentIssuedOn": "2024-09-24T00:00:00",
+          "documentIssuedOn": "2024-09-24",
           "attachmentId": "9d5a87a204d2c487407f5660a56b257c378fc0b04f87ae5c3d812f0b013aa9c1",
           "attachmentFilename": "383d6f25bf1eb0d181b335917885e14062286c44c98dabc7128e831302630cc9",
           "attachmentContentType": "application/pdf",
@@ -366,7 +366,7 @@
         {
           "documentType": "OriginCertificate",
           "documentReference": "068e40551ec64d89dba617490a965108d05a414345fadd4cd4b71939a90887c0",
-          "documentIssuedOn": "2024-10-10T00:00:00",
+          "documentIssuedOn": "2024-10-10",
           "attachmentId": "4dfbaf78654f4f891a72d4152dd7cee883b100d073b7e65b34ac5b8c51b3b4bf",
           "attachmentFilename": "0da247f4dfed523a34a892059da9a31d3f6b13b279471500e4f0008bcde8bcd4",
           "attachmentContentType": "application/pdf",

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5118377.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5118377.verified.json
@@ -496,7 +496,7 @@
         {
           "documentType": "HealthCertificate",
           "documentReference": "77846b610284ab6393d11f3e6b0e7694074492a77a7289bc912011fe5564d44d",
-          "documentIssuedOn": "2024-09-09T00:00:00",
+          "documentIssuedOn": "2024-09-09",
           "attachmentId": "04f2d789017cded6d5320127c51f33ce67382a2b865f51bdf61ddd98a2d712bd",
           "attachmentFilename": "cc6c5a728e3a6d6e488c385bb42dc201878b783a69d966d6be97f7a96a99cda1",
           "attachmentContentType": "application/pdf",
@@ -630,11 +630,11 @@
           },
           "laboratoryTestResult": {
             "sampleUseByDate": "2024-11-29",
-            "releasedOn": "2024-12-16T00:00:00",
+            "releasedOn": "2024-12-16",
             "laboratoryTestMethod": "6e6783d3b6cb3e99dca804828bbd0b0b4a6a4deec97e553f00f5a49ab78d8e9f",
             "results": "e693f28d32b4173f08b31e1e02b8339dc74b0f10d25f8736719c03eb97d98f38",
             "conclusion": "Satisfactory",
-            "labTestCreatedOn": "2024-11-28T00:00:00"
+            "labTestCreatedOn": "2024-11-28"
           }
         },
         {
@@ -662,11 +662,11 @@
           },
           "laboratoryTestResult": {
             "sampleUseByDate": "2024-11-29",
-            "releasedOn": "2024-12-16T00:00:00",
+            "releasedOn": "2024-12-16",
             "laboratoryTestMethod": "890a443e87b8e556ad2b07706c88fd37354f0ab016bbf05e0c3d4eade369463f",
             "results": "0cc4bcf7987659590251cd674974be4a60e6fe4fbcc47d837ae72cec6bb90435",
             "conclusion": "Satisfactory",
-            "labTestCreatedOn": "2024-11-28T00:00:00"
+            "labTestCreatedOn": "2024-11-28"
           }
         }
       ]

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5226413.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5226413.verified.json
@@ -346,7 +346,7 @@
         {
           "documentType": "CommercialInvoice",
           "documentReference": "e31c11bc1edb70ef356a187dec01aa2aa3889e7eaf481c52aa9440d4d60f2f63",
-          "documentIssuedOn": "2024-11-27T00:00:00",
+          "documentIssuedOn": "2024-11-27",
           "attachmentId": "a029aac7f3311e98fe647afd34bd3e5d11b07e4ad57e34ad4d59eaeda7e5c136",
           "attachmentFilename": "003b568fd50fe9ef55a390d9df09fde7e6d40507979f0acc0cd138915c2a5b70",
           "attachmentContentType": "application/pdf",

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5351769.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5351769.verified.json
@@ -323,7 +323,7 @@
         {
           "documentType": "OriginCertificate",
           "documentReference": "d1d62341b70b660e12b2bf7f76d3f6337467268a82f7f87e42673f3f33cb804b",
-          "documentIssuedOn": "2024-12-20T00:00:00",
+          "documentIssuedOn": "2024-12-20",
           "attachmentId": "e58c5ffa9865c39ef309e82cbfb7be0f29c4da39c91a050966d44fc88d09ec97",
           "attachmentFilename": "c800d449dcb0e06240e390350dc2aafe4039986fa76515d5b8868a09b4f9ecb6",
           "attachmentContentType": "application/pdf",
@@ -334,7 +334,7 @@
         {
           "documentType": "CommercialInvoice",
           "documentReference": "5ef5014a08452444c531cca33bf03b77a9449b601fcd1d8cacd4dd344a574498",
-          "documentIssuedOn": "2024-12-20T00:00:00",
+          "documentIssuedOn": "2024-12-20",
           "attachmentId": "2842083402a4ff9d9238eac43b43cd642dd0015132d28b489eba7f2fdc232f58",
           "attachmentFilename": "a991181fd2d5262c87e78ff2a5ddcef1aace7f9b9f5c8cc6ddc3241d8f661acd",
           "attachmentContentType": "application/pdf",
@@ -345,7 +345,7 @@
         {
           "documentType": "PhytosanitaryCertificate",
           "documentReference": "7959e75a3d3b211fb4cc3a63c68ee589b9adb1da572074f92503c4f61ee1ec14",
-          "documentIssuedOn": "2024-12-20T00:00:00",
+          "documentIssuedOn": "2024-12-20",
           "attachmentId": "37bc9c8d845308cc621b7600f9d0a34e188b189b2f5c55cb3190f3ea8056300d",
           "attachmentFilename": "446083157aca3c5cdd65a0fbe8998a5981289fb3cf4df0ef951e8c2f66e5d77f",
           "attachmentContentType": "application/pdf",
@@ -356,7 +356,7 @@
         {
           "documentType": "Other",
           "documentReference": "d5bc60867c727385f325eacc30ee1204f41ff2fe8845a2e68f72ed78604c9c75",
-          "documentIssuedOn": "2024-12-21T00:00:00",
+          "documentIssuedOn": "2024-12-21",
           "attachmentId": "53ebe2966a713178e67e3704bcb17a5cb5ec1278a06996ff2ed4204d7e3893c8",
           "attachmentFilename": "a5495b6597a39c16013cb42ab9bc7ef3d388d3dbe741ed60999aa6f7a6b281f6",
           "attachmentContentType": "application/pdf",

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.4144842.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.4144842.verified.json
@@ -269,7 +269,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "f28c7d080ab8914162bb189bcab266dc48b700f2671c371f092a48663815bb14",
-          "documentIssuedOn": "2024-03-21T00:00:00",
+          "documentIssuedOn": "2024-03-21",
           "attachmentId": null,
           "attachmentFilename": null,
           "attachmentContentType": null,

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5093007.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5093007.verified.json
@@ -333,7 +333,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "a589ecb082d731c8e0c49baaa0932de7ddd19555e2b31d62f4dd2303adfc3ff9",
-          "documentIssuedOn": "2024-10-16T00:00:00",
+          "documentIssuedOn": "2024-10-16",
           "attachmentId": "5f50325983654d9632974500107efda4b1b2925e062459d10e506b00209c84fa",
           "attachmentFilename": "d993508ace633cbfb44d77efb72e15b3465cb9b0cd647d43c4cf677eedefae56",
           "attachmentContentType": "application/pdf",
@@ -344,7 +344,7 @@
         {
           "documentType": "Other",
           "documentReference": "65a30cdecc4d51346fcc1846e27d7d28052dbdc75a5715c3b114c7778df9445b",
-          "documentIssuedOn": "2024-11-04T00:00:00",
+          "documentIssuedOn": "2024-11-04",
           "attachmentId": "5b80ec4fd59e9edcbe1a44c0c15f7834699b25e85b5e908b6c40b7c47b300ee2",
           "attachmentFilename": "961ae7923779a30cdf38bbeedc766048e3116db502c87fd97893a049abff9302",
           "attachmentContentType": "application/pdf",

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5101765.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5101765.verified.json
@@ -267,7 +267,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "9b3dae56d091a018266803052c10fe85f85e6b9bb72b1909c48c55609dfca840",
-          "documentIssuedOn": "2024-11-11T00:00:00",
+          "documentIssuedOn": "2024-11-11",
           "attachmentId": "8c67a2e5fefa4b629ad5eb65cf18761175a409660d952680bef4d1cb281e9e89",
           "attachmentFilename": "734cf101677129e75afa5ef9b1090483ce15c4a42f96e8debf9162597a6d25b7",
           "attachmentContentType": "application/pdf",
@@ -278,7 +278,7 @@
         {
           "documentType": "CommercialInvoice",
           "documentReference": "b8ecbc0adf2537651d6f52172f6ff871b97f58a893bb375d92119ffbeea54ebf",
-          "documentIssuedOn": "2024-11-11T00:00:00",
+          "documentIssuedOn": "2024-11-11",
           "attachmentId": "8f922d627310d65c98c8f17a7ac7b67c4f2cc0759fae18c3a4dd0fd2474cefb6",
           "attachmentFilename": "d2f49912db4e8afb6e7deb188beda0a6a3f725dd50434f5b9aa6fa0649ea8912",
           "attachmentContentType": "application/pdf",
@@ -289,7 +289,7 @@
         {
           "documentType": "Other",
           "documentReference": "1c4cc57d6db62864cc55065592d58f15db7b0b4c3c137eff56ead805e78cf88c",
-          "documentIssuedOn": "2024-11-11T00:00:00",
+          "documentIssuedOn": "2024-11-11",
           "attachmentId": "552a744557222f3a17d49bbf9636f53a44da384eee7ce988bc6ff93409a573a6",
           "attachmentFilename": "5b09071db6e62d3cc88edcd1902d0cf7d3a46d8cbdd979f991aa5265324167ff",
           "attachmentContentType": "application/pdf",

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5125476.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5125476.verified.json
@@ -1,6 +1,7 @@
 ﻿{
   "goodsMovements": [
     {
+      "updated": "2025-02-21T13:28:40.129Z",
       "id": "GMRA00KBHFE0",
       "state": "Completed",
       "updatedSource": "2024-11-11T17:34:50.774Z",
@@ -15,6 +16,14 @@
       "actualCrossing": {
         "routeId": "32",
         "arrivesAt": "2024-11-11T18:20:00"
+      },
+      "declarations": {
+        "transits": [
+          {
+            "id": "24IEDUB10010972672"
+          }
+        ],
+        "customs": null
       }
     }
   ],
@@ -458,7 +467,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "c48a4885909fa7f105566e398d633fd10c4e06e7c56582b5566beb20323e69a8",
-          "documentIssuedOn": "2024-11-11T00:00:00",
+          "documentIssuedOn": "2024-11-11",
           "attachmentId": "6936766e4fc5f60aad91579a4c87b3b1fee75c06a0f16e470c1a0722d32aed85",
           "attachmentFilename": "17913c2cac77aa0b9cc9c21bd6797786cbeea4f812ac9fb46dd6ad75e8941451",
           "attachmentContentType": "application/pdf",
@@ -469,7 +478,7 @@
         {
           "documentType": "Other",
           "documentReference": "6f9c1dd780e9c23fd81535bc9d0c18200b3a0d1fef88e14baed11a5188734cd2",
-          "documentIssuedOn": "2024-11-11T00:00:00",
+          "documentIssuedOn": "2024-11-11",
           "attachmentId": "fc8ac44c87b3f4ccf645b7763caeb880d46b31a2bac04edeee8abf74e5b90587",
           "attachmentFilename": "ccce0b56f39fe9cacc5024b3417d0170da7ff52d01007d683dfa9923a7405b12",
           "attachmentContentType": "application/pdf",
@@ -480,7 +489,7 @@
         {
           "documentType": "Other",
           "documentReference": "6f9c1dd780e9c23fd81535bc9d0c18200b3a0d1fef88e14baed11a5188734cd2",
-          "documentIssuedOn": "2024-11-11T00:00:00",
+          "documentIssuedOn": "2024-11-11",
           "attachmentId": "f4ab67cea0da87b172b3cb7f5d91510d1307f7bca54f82dd15a156967560d031",
           "attachmentFilename": "e1cd8d6705800909ce331836a34bde3002e8522697dd535c470906ed07e6bae3",
           "attachmentContentType": "application/pdf",

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5132323.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5132323.verified.json
@@ -314,7 +314,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "2fe472a58cff14c602d38e4e29ff6d4214a6081c8464f6c5c5e671485690cf4a",
-          "documentIssuedOn": "2024-11-12T00:00:00",
+          "documentIssuedOn": "2024-11-12",
           "attachmentId": "713b003906f1afa6947c3f4068b78c84b695a279f957c93b41f47d827a736e5e",
           "attachmentFilename": "e90a09ca212176e494bbec114781ebde7f478d6a508ca7d3ff45ead6f3fa76d4",
           "attachmentContentType": "application/pdf",
@@ -325,7 +325,7 @@
         {
           "documentType": "CommercialInvoice",
           "documentReference": "a9a2630ea14352e02e460e6f632c0ac44fd83b034b85701fd2bfd76ca3a05e62",
-          "documentIssuedOn": "2024-11-11T00:00:00",
+          "documentIssuedOn": "2024-11-11",
           "attachmentId": "a8e6d2dbd895e4cee2b0373469d2d13e1e09c874acd5f1d0d42e1799a225c297",
           "attachmentFilename": "6ce9ae1d1c1108c0f15d82baa4b4cca74ce40fec7daf2b6910e5d3179e0ad88d",
           "attachmentContentType": "application/pdf",
@@ -336,7 +336,7 @@
         {
           "documentType": "Other",
           "documentReference": "9deaa34326a253e841d801f8341e10a00d3f48c5314fc97ad30c6acb47a176fb",
-          "documentIssuedOn": "2024-11-11T00:00:00",
+          "documentIssuedOn": "2024-11-11",
           "attachmentId": "769b502ca4219b85d5cce199ee2e34af954dbe6924b964f5ad07e07c118f06c8",
           "attachmentFilename": "9bf0df81423e9eaa7aa5c42f133490dcac5e9440f929f78c912cc3ed2187dcab",
           "attachmentContentType": "application/pdf",

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5137241.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5137241.verified.json
@@ -389,7 +389,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "66ff86f2d298118d3e1db3e43d74e91c5b8a189c14180664544745fa96c4a64a",
-          "documentIssuedOn": "2024-10-21T00:00:00",
+          "documentIssuedOn": "2024-10-21",
           "attachmentId": null,
           "attachmentFilename": null,
           "attachmentContentType": null,

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5140733.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5140733.verified.json
@@ -449,7 +449,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "ada5519c8fa052472d5fbdb45cae245a1167588365adc2997078d19105bb7b79",
-          "documentIssuedOn": "2024-09-23T00:00:00",
+          "documentIssuedOn": "2024-09-23",
           "attachmentId": null,
           "attachmentFilename": null,
           "attachmentContentType": null,

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5192091.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5192091.verified.json
@@ -426,7 +426,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "764273ba6e0f530452484827a838c427218194b9625aa9702a3867396f53e7f4",
-          "documentIssuedOn": "2024-11-18T00:00:00",
+          "documentIssuedOn": "2024-11-18",
           "attachmentId": "7999228915fdf80cbcd19b61eee9a08b5d50958ed44fae21175aa3a9a8ed262c",
           "attachmentFilename": "e2e321a0743360a7a4106d21cf7be10fc7052bbcef9865bfc26fc2a768ca87d1",
           "attachmentContentType": "application/pdf",
@@ -437,7 +437,7 @@
         {
           "documentType": "CommercialInvoice",
           "documentReference": "8d8f9afd23c3a7da4f61f4d067c8467a67f6a089bc29eb4eb93e974de224c532",
-          "documentIssuedOn": "2024-11-22T00:00:00",
+          "documentIssuedOn": "2024-11-22",
           "attachmentId": "4aaa082bd1b0ea4293985924da0a0407762daf0b9cf507e9ba11819de464bd2f",
           "attachmentFilename": "6578a1abe4e86efd759db3c2d3bf26d583e45201249b126583c9c4108f60df7f",
           "attachmentContentType": "application/pdf",
@@ -448,7 +448,7 @@
         {
           "documentType": "Other",
           "documentReference": "9cc8b4673481cc36e07eefbc61c5e62f9465150b9df8f4afaaa30baea22063d4",
-          "documentIssuedOn": "2024-11-22T00:00:00",
+          "documentIssuedOn": "2024-11-22",
           "attachmentId": "f86a3c0709038c986c3f05f02a526e324d0c5c1748d26b6a84a33df6156fadd9",
           "attachmentFilename": "0ce2e78e3ff4142362157bf3abeec1e89f292e0384fdc12feb056c333e1d6d63",
           "attachmentContentType": "application/pdf",
@@ -459,7 +459,7 @@
         {
           "documentType": "Other",
           "documentReference": "891d96937bc5ba3a32283e9fc8eb6bad853eee8844ede2f72774ae9b311a3a6c",
-          "documentIssuedOn": "2024-11-22T00:00:00",
+          "documentIssuedOn": "2024-11-22",
           "attachmentId": "21278dc885fbbadf59ea3d6ed593dd4be9a1f39467a589c61b06b5fb4b89ebc2",
           "attachmentFilename": "768d7bc23f5a9008dd884777f9fc2bf3979d7d6deb7aaec817f7e9a631393496",
           "attachmentContentType": "application/pdf",
@@ -470,7 +470,7 @@
         {
           "documentType": "ProcessingStatement",
           "documentReference": "7c29bf7899d2ae6c7e7215e35ab891efc208815719bd5e2758dae8c57a3ea077",
-          "documentIssuedOn": "2024-11-15T00:00:00",
+          "documentIssuedOn": "2024-11-15",
           "attachmentId": "c2665a8e189cd8629856ccda57e32d66bdf97a266b8ae312a9b15b44a1bf8965",
           "attachmentFilename": "4aa86e9aa1375d2306ed46e61f909a9882373995e3edda0880369d87e9e3ecae",
           "attachmentContentType": "application/pdf",
@@ -481,7 +481,7 @@
         {
           "documentType": "ProcessingStatement",
           "documentReference": "430676fb9f46673cd090f68d21547f92479694d77f6b31bba6cb7bbb71d0d862",
-          "documentIssuedOn": "2024-11-22T00:00:00",
+          "documentIssuedOn": "2024-11-22",
           "attachmentId": "a23e26cbec99859e8bc3004b4c4fc4a5d0b3997af7496ec2669d73b1589dbb60",
           "attachmentFilename": "c6deff151c6eadd41e3889f106da702a668aa10fbb257f7f1f0edfdb186e43b4",
           "attachmentContentType": "application/pdf",
@@ -492,7 +492,7 @@
         {
           "documentType": "ProcessingStatement",
           "documentReference": "a70e52fbf2148b64e9dcbd8dce1525431f4b8a70060126cdc61914c3c73d2e90",
-          "documentIssuedOn": "2024-11-21T00:00:00",
+          "documentIssuedOn": "2024-11-21",
           "attachmentId": "1edaf5c4c8d9fdd7cc958b751987cc72519deeb6541e8bca9981e285f77e37bd",
           "attachmentFilename": "375413321d927c3763be77ab01978f6dd9beb4c5101122d8d19c6dc2adfc399f",
           "attachmentContentType": "application/pdf",

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5249145.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5249145.verified.json
@@ -504,7 +504,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "987dc7011f15fbae6879ab3af2d508d3a3b97408f90c21a5c1a1c92d71086338",
-          "documentIssuedOn": "2024-10-12T00:00:00",
+          "documentIssuedOn": "2024-10-12",
           "attachmentId": null,
           "attachmentFilename": null,
           "attachmentContentType": null,

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5253621.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5253621.verified.json
@@ -400,7 +400,7 @@
         {
           "documentType": "Other",
           "documentReference": "9b0feb8987d903dfb4855869ff45e40718cbb9e567d65e78a7fda5e244bf5334",
-          "documentIssuedOn": "2024-12-04T00:00:00",
+          "documentIssuedOn": "2024-12-04",
           "attachmentId": "8f79b243-1399-4d2d-8274-7349f1db14cf",
           "attachmentFilename": "SKM_C450i24120411400.pdf",
           "attachmentContentType": "application/pdf",
@@ -411,7 +411,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "a1a8c1d3589670d2f26a68a70bf0d9ab11c04d9f6c10c158c41745c08b6ac2e5",
-          "documentIssuedOn": "2024-11-13T00:00:00",
+          "documentIssuedOn": "2024-11-13",
           "attachmentId": null,
           "attachmentFilename": null,
           "attachmentContentType": null,

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5270338.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5270338.verified.json
@@ -279,7 +279,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "e16e7dc409c3684ae64aa0675a34a896a175fb5d9f06703c7df867de4f553d29",
-          "documentIssuedOn": "2024-12-05T00:00:00",
+          "documentIssuedOn": "2024-12-05",
           "attachmentId": "4f9a3623048cee23b587faf8645064911b31a662b952129b3614a36b8c935e92",
           "attachmentFilename": "4f6d3b87451b763f39ae639faca213c9cd50b995f15da4507f03615d597ab18f",
           "attachmentContentType": "application/pdf",

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5328437.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5328437.verified.json
@@ -409,7 +409,7 @@
         {
           "documentType": "LatestVeterinaryHealthCertificate",
           "documentReference": "251846972b2d5ca51900ead3458bd7f81292357dab43e83f7d7f1f4d59767328",
-          "documentIssuedOn": "2024-10-28T00:00:00",
+          "documentIssuedOn": "2024-10-28",
           "attachmentId": null,
           "attachmentFilename": null,
           "attachmentContentType": null,

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDPP.GB.2024.3726460.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDPP.GB.2024.3726460.verified.json
@@ -289,7 +289,7 @@
         {
           "documentType": "PhytosanitaryCertificate",
           "documentReference": "257df25c243825547f15207ab3904d3d22280e16354ed2baeadb106d24e45fe3",
-          "documentIssuedOn": "2023-12-13T00:00:00",
+          "documentIssuedOn": "2023-12-13",
           "attachmentId": "3bb4789f161a28793539c52c1a8e7fcd24c9ec4f914a1ac3e8afb15c9476fe43",
           "attachmentFilename": "38675d9f8074f4ea34cad78600c3075bb56240e4b0e2b9e30e77322d74cce9ca",
           "attachmentContentType": "application/pdf",
@@ -300,7 +300,7 @@
         {
           "documentType": "CommercialInvoice",
           "documentReference": "84bd2258901c94635ee3ff740e00a02d3f45cd38987722d376c2dd794282f37e",
-          "documentIssuedOn": "2023-12-18T00:00:00",
+          "documentIssuedOn": "2023-12-18",
           "attachmentId": "8c51b863187448f91e5587fcc3b063b5dbd286e8e242dad26b54e98368230162",
           "attachmentFilename": "7cd10ac90d29968c99ea065e8d13a82435fdbcd38c6ab3cc783c2fa375b94e7d",
           "attachmentContentType": "application/pdf",

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -214,7 +214,7 @@
           "documentIssuedOn": {
             "type": "string",
             "description": "Additional document issue date",
-            "format": "date-time",
+            "format": "date",
             "nullable": true
           },
           "attachmentId": {
@@ -594,7 +594,7 @@
           "issuedOn": {
             "type": "string",
             "description": "Catch certificate date of issue",
-            "format": "date-time",
+            "format": "date",
             "nullable": true
           },
           "flagState": {
@@ -1317,6 +1317,16 @@
         ],
         "type": "string"
       },
+      "Customs": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "CustomsClearanceDecision": {
         "type": "object",
         "properties": {
@@ -1452,6 +1462,7 @@
           "notAcceptableActionByDate": {
             "type": "string",
             "description": "Filled when consignmentAcceptable is set to false",
+            "format": "date",
             "nullable": true
           },
           "chedppNotAcceptableReasons": {
@@ -1786,13 +1797,35 @@
         ],
         "type": "string"
       },
+      "Declarations": {
+        "type": "object",
+        "properties": {
+          "transits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Transits"
+            },
+            "description": "A list of declaration ids.",
+            "nullable": true
+          },
+          "customs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Customs"
+            },
+            "description": "A list of declaration ids.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "DetailsOnReExport": {
         "type": "object",
         "properties": {
           "date": {
             "type": "string",
             "description": "Date of re-export",
-            "format": "date-time",
+            "format": "date",
             "nullable": true
           },
           "meansOfTransportNo": {
@@ -2068,8 +2101,15 @@
         "additionalProperties": false
       },
       "Gmr": {
+        "required": [
+          "updated"
+        ],
         "type": "object",
         "properties": {
+          "updated": {
+            "type": "string",
+            "format": "date-time"
+          },
           "id": {
             "type": "string",
             "description": "The Goods Movement Record (GMR) ID for this GMR.  Do not include when POSTing a GMR - GVMS will assign an ID.",
@@ -2128,6 +2168,14 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/ActualCrossing"
+              }
+            ],
+            "nullable": true
+          },
+          "declarations": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Declarations"
               }
             ],
             "nullable": true
@@ -2749,7 +2797,7 @@
           "releasedOn": {
             "type": "string",
             "description": "When it was released",
-            "format": "date-time",
+            "format": "date",
             "nullable": true
           },
           "laboratoryTestMethod": {
@@ -2774,7 +2822,7 @@
           "labTestCreatedOn": {
             "type": "string",
             "description": "Date of lab test created in IPAFFS",
-            "format": "date-time",
+            "format": "date",
             "nullable": true
           }
         },
@@ -3749,6 +3797,7 @@
           "exitDate": {
             "type": "string",
             "description": "Exit date when import or admission",
+            "format": "date",
             "nullable": true
           },
           "finalBip": {
@@ -3967,6 +4016,16 @@
         ],
         "type": "string"
       },
+      "Transits": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "UpdatedImportNotification": {
         "required": [
           "links",
@@ -4094,6 +4153,7 @@
           "veterinaryDocumentIssuedOn": {
             "type": "string",
             "description": "Veterinary document issue date",
+            "format": "date",
             "nullable": true
           },
           "accompanyingDocumentNumbers": {

--- a/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WithGoodsMovements_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5125476.verified.txt
+++ b/tests/Api.Tests/Services/Btms/BtmsServiceTests.GetImportNotification_WithGoodsMovements_WhenOk_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5125476.verified.txt
@@ -7,6 +7,7 @@
       CreatedSource: null,
       Created: null,
       UpdatedEntity: null,
+      Updated: 2025-02-21 13:28:40.129 Utc,
       AuditEntries: null,
       Relationships: null,
       Id: GMRA00KBHFE0,
@@ -29,6 +30,14 @@
       ActualCrossing: {
         RouteId: 32,
         ArrivesAt: 2024-11-11 18:20
+      },
+      Declarations: {
+        Transits: [
+          {
+            Id: 24IEDUB10010972672
+          }
+        ],
+        Customs: null
       }
     }
   ],

--- a/tools/SchemaToCSharp/DotNetTypes.cs
+++ b/tools/SchemaToCSharp/DotNetTypes.cs
@@ -1,0 +1,12 @@
+namespace SchemaToCSharp;
+
+public static class DotNetTypes
+{
+    public const string Int = "int";
+    public const string Decimal = "decimal";
+    public const string Bool = "bool";
+    public const string Object = "object";
+    public const string String = "string";
+    public const string DateTime = "DateTime";
+    public const string DateOnly = "DateOnly";
+}

--- a/tools/SchemaToCSharp/OpenApiFormats.cs
+++ b/tools/SchemaToCSharp/OpenApiFormats.cs
@@ -1,0 +1,7 @@
+namespace SchemaToCSharp;
+
+public static class OpenApiFormats
+{
+    public const string DateTime = "date-time";
+    public const string Date = "date";
+}

--- a/tools/SchemaToCSharp/OpenApiTypes.cs
+++ b/tools/SchemaToCSharp/OpenApiTypes.cs
@@ -1,0 +1,11 @@
+namespace SchemaToCSharp;
+
+public static class OpenApiTypes
+{
+    public const string String = "string";
+    public const string Integer = "integer";
+    public const string Number = "number";
+    public const string Boolean = "boolean";
+    public const string Object = "object";
+    public const string Array = "array";
+}

--- a/tools/SchemaToCSharp/Program.cs
+++ b/tools/SchemaToCSharp/Program.cs
@@ -27,9 +27,9 @@ foreach (var (schemaName, schema) in openApiDocument.Components.Schemas)
 {
     var syntax = schema.Type switch
     {
-        "integer" => CreateEnumSyntax(),
-        "string" => CreateEnumSyntax(),
-        "object" => CreateTypeSyntax(),
+        OpenApiTypes.Integer => CreateEnumSyntax(),
+        OpenApiTypes.String => CreateEnumSyntax(),
+        OpenApiTypes.Object => CreateTypeSyntax(),
         _ => throw new ArgumentOutOfRangeException(schema.Type, "Unknown schema type"),
     };
 
@@ -72,32 +72,32 @@ static TypeSyntax CreatePropertyType(OpenApiSchema schema)
 
     var typeName = schema.Type switch
     {
-        "string" => CreateStringReferenceTypeName(schema),
-        "integer" => CreateReferenceTypeName(schema, "int"),
-        "number" => "decimal",
-        "boolean" => "bool",
-        "object" => CreateReferenceTypeName(schema, schema.Type),
-        "array" => CreateReferenceTypeName(schema.Items, schema.Items.Type),
-        _ => "object",
+        OpenApiTypes.String => CreateStringReferenceTypeName(schema),
+        OpenApiTypes.Integer => CreateReferenceTypeName(schema, DotNetTypes.Int),
+        OpenApiTypes.Number => DotNetTypes.Decimal,
+        OpenApiTypes.Boolean => DotNetTypes.Bool,
+        OpenApiTypes.Object => CreateReferenceTypeName(schema, schema.Type),
+        OpenApiTypes.Array => CreateReferenceTypeName(schema.Items, schema.Items.Type),
+        _ => DotNetTypes.Object,
     };
 
     typeName = CreateTypeName(typeName);
 
-    return ParseTypeName(schema.Type == "array" ? $"List<{typeName}>" : typeName);
+    return ParseTypeName(schema.Type == OpenApiTypes.Array ? $"List<{typeName}>" : typeName);
 }
 
 static string CreateStringReferenceTypeName(OpenApiSchema schema)
 {
     if (schema.Enum.Any())
     {
-        return CreateReferenceTypeName(schema, "string");
+        return CreateReferenceTypeName(schema, DotNetTypes.String);
     }
 
     return schema.Format switch
     {
-        "date-time" => "DateTime",
-        "date" => "DateOnly",
-        _ => "string",
+        OpenApiFormats.DateTime => DotNetTypes.DateTime,
+        OpenApiFormats.Date => DotNetTypes.DateOnly,
+        _ => DotNetTypes.String,
     };
 }
 

--- a/tools/SchemaToCSharp/Program.cs
+++ b/tools/SchemaToCSharp/Program.cs
@@ -93,7 +93,12 @@ static string CreateStringReferenceTypeName(OpenApiSchema schema)
         return CreateReferenceTypeName(schema, "string");
     }
 
-    return schema.Format == "date-time" ? "DateTime" : "string";
+    return schema.Format switch
+    {
+        "date-time" => "DateTime",
+        "date" => "DateOnly",
+        _ => "string",
+    };
 }
 
 static string CreateReferenceTypeName(OpenApiSchema schema, string defaultTypeName) =>


### PR DESCRIPTION
As per PR title.

Take generated `openapi.json` artifact from build https://github.com/DEFRA/btms-backend/actions/runs/13503451073 and run through schema generation steps.

Some changes relate to a missed case of handling `DateOnly` types (they were coming through as strings by default, now they are not).

Additional verify test output shows the expected data being retrieved from the BtmsService and then none of it leaks into our API response, only the updated values, which is what is expected.