### PR TITLE
Change property name to plural as it's an array

### DIFF
--- a/Defra.PhaImportNotifications.sln.DotSettings
+++ b/Defra.PhaImportNotifications.sln.DotSettings
@@ -9,4 +9,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cveda/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cvedp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cvedpp/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=finalisations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gmrs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Contracts/ImportNotification.cs
+++ b/src/Contracts/ImportNotification.cs
@@ -10,7 +10,7 @@ public partial record ImportNotification
     [JsonPropertyName("clearanceDecisions")]
     public IReadOnlyList<CustomsClearanceDecision>? ClearanceDecisions { get; init; }
 
-    [JsonPropertyName("finalisation")]
+    [JsonPropertyName("finalisations")]
     public IReadOnlyList<Finalisation>? Finalisations { get; init; }
 
     [JsonPropertyName("goodsMovements")]

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5019877.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5019877.verified.json
@@ -61,7 +61,7 @@
       ]
     }
   ],
-  "finalisation": [
+  "finalisations": [
     {
       "finalState": "Cleared",
       "manualAction": false,

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5118377.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDD.GB.2024.5118377.verified.json
@@ -233,7 +233,7 @@
       ]
     }
   ],
-  "finalisation": [
+  "finalisations": [
     {
       "finalState": "Cleared",
       "manualAction": false,

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5253621.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5253621.verified.json
@@ -121,7 +121,7 @@
       ]
     }
   ],
-  "finalisation": [
+  "finalisations": [
     {
       "finalState": "Cleared",
       "manualAction": false,

--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5328437.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.Get_AllStubs_ShouldSucceed_chedReferenceNumber=CHEDP.GB.2024.5328437.verified.json
@@ -118,7 +118,7 @@
       ]
     }
   ],
-  "finalisation": [
+  "finalisations": [
     {
       "finalState": "Cleared",
       "manualAction": false,

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -2272,7 +2272,7 @@
             },
             "nullable": true
           },
-          "finalisation": {
+          "finalisations": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Finalisation"


### PR DESCRIPTION
As per PR title.

Previously, finalisations were returned as an array with property name `finalisation`, which suggested a single value. It can be more than one so make the property name plural. 