### PR TITLE
PHAIN-159 Add test for Get endpoint for FSA user

### DIFF
--- a/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ImportNotifications/GetTests.cs
@@ -48,7 +48,7 @@ public class GetTests : EndpointTestBase, IClassFixture<WireMockContext>
     [ClassData(typeof(AllStubChedReferenceNumbers))]
     public async Task Get_AllStubs_ShouldSucceed(string chedReferenceNumber)
     {
-        var client = CreateClient();
+        var client = CreateClient("pha");
 
         WireMock.StubAllMovements();
         WireMock.StubAllGmrs();
@@ -70,6 +70,19 @@ public class GetTests : EndpointTestBase, IClassFixture<WireMockContext>
             foreach (var chedReferenceNumber in WireMockExtensions.GetAllStubChedReferenceNumbers())
                 Add(chedReferenceNumber);
         }
+    }
+
+    [Fact]
+    public async Task Get_WhenAuthorisedForAllBcps_ShouldSucceed()
+    {
+        var chedReferenceNumber = Testing.ChedReferenceNumbers.ChedA;
+        var client = CreateClient("fsa");
+
+        WireMock.StubSingleImportNotification(chedReferenceNumber: chedReferenceNumber);
+
+        var response = await client.GetAsync(Testing.Endpoints.ImportNotifications.Get(chedReferenceNumber));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]


### PR DESCRIPTION
[PHAIN-159](https://eaflood.atlassian.net/browse/PHAIN-159)

Adds a test to ensure that the Get individual notification endpoint works when the user is authorised to access all BCPs (i.e. is the FSA user)

[PHAIN-159]: https://eaflood.atlassian.net/browse/PHAIN-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ