### PR TITLE
PHAIN-173 : Publish http server metrics to AWS EMF

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -12,6 +12,7 @@
     <InternalsVisibleTo Include="Defra.PhaImportNotifications.Tests" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Amazon.CloudWatch.EMF" Version="2.2.0" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.18.1" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.18.1" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />

--- a/src/Api/Metrics/ApplicationBuilderExtensions.cs
+++ b/src/Api/Metrics/ApplicationBuilderExtensions.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Defra.PhaImportNotifications.Api.Metrics;
+
+[ExcludeFromCodeCoverage]
+public static class ApplicationBuilderExtensions
+{
+    public static IApplicationBuilder UseEmfExporter(this IApplicationBuilder builder, string ns)
+    {
+        var config = builder.ApplicationServices.GetRequiredService<IConfiguration>();
+        var enabled = config.GetValue("AWS_EMF_ENABLED", true);
+
+        if (enabled)
+        {
+            var nsc = config.GetValue<string>("AWS_EMF_NAMESPACE");
+            var env = config.GetValue<string>("AWS_EMF_ENVIRONMENT") ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(nsc) && env.Equals("Local"))
+                nsc = ns;
+
+            if (string.IsNullOrWhiteSpace(nsc))
+                throw new InvalidOperationException("AWS_EMF_NAMESPACE is not set but metrics are enabled");
+
+            EmfExporter.Init(builder.ApplicationServices.GetRequiredService<ILoggerFactory>(), nsc);
+        }
+
+        return builder;
+    }
+}

--- a/src/Api/Metrics/EmfExporter.cs
+++ b/src/Api/Metrics/EmfExporter.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
+using Amazon.CloudWatch.EMF.Logger;
+using Amazon.CloudWatch.EMF.Model;
+using Microsoft.Extensions.Logging.Abstractions;
+using Unit = Amazon.CloudWatch.EMF.Model.Unit;
+
+namespace Defra.PhaImportNotifications.Api.Metrics;
+
+[ExcludeFromCodeCoverage]
+public static class EmfExporter
+{
+    private static readonly MeterListener s_meterListener = new();
+    private static ILogger s_logger = null!;
+    private static ILoggerFactory s_loggerFactory = NullLoggerFactory.Instance;
+    private static string? s_awsNamespace;
+
+    public static void Init(ILoggerFactory loggerFactory, string? awsNamespace)
+    {
+        s_logger = loggerFactory.CreateLogger(nameof(EmfExporter));
+        s_loggerFactory = loggerFactory;
+        s_awsNamespace = awsNamespace;
+
+        s_meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name is MetricsConstants.MetricNames.MeterName)
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        s_meterListener.SetMeasurementEventCallback<int>(OnMeasurementRecorded);
+        s_meterListener.SetMeasurementEventCallback<long>(OnMeasurementRecorded);
+        s_meterListener.SetMeasurementEventCallback<double>(OnMeasurementRecorded);
+        s_meterListener.Start();
+    }
+
+    private static void OnMeasurementRecorded<T>(
+        Instrument instrument,
+        T measurement,
+        ReadOnlySpan<KeyValuePair<string, object?>> tags,
+        object? state
+    )
+    {
+        try
+        {
+            using var metricsLogger = new MetricsLogger(s_loggerFactory);
+
+            metricsLogger.SetNamespace(s_awsNamespace);
+            var dimensionSet = new DimensionSet();
+
+            foreach (var tag in tags)
+            {
+                if (string.IsNullOrWhiteSpace(tag.Value?.ToString()))
+                    continue;
+
+                dimensionSet.AddDimension(tag.Key, tag.Value!.ToString());
+            }
+
+            metricsLogger.SetDimensions(dimensionSet);
+            metricsLogger.PutMetric(instrument.Name, Convert.ToDouble(measurement), Enum.Parse<Unit>(instrument.Unit!));
+            metricsLogger.Flush();
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogWarning(ex, "Failed to push EMF metric");
+        }
+    }
+}

--- a/src/Api/Metrics/MetricsConstants.cs
+++ b/src/Api/Metrics/MetricsConstants.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Defra.PhaImportNotifications.Api.Metrics;
+
+[ExcludeFromCodeCoverage]
+public static class MetricsConstants
+{
+    public static class MetricNames
+    {
+        public const string MeterName = "Defra.TradeImportsDataApi.Api";
+    }
+}

--- a/src/Api/Metrics/MetricsMiddleware.cs
+++ b/src/Api/Metrics/MetricsMiddleware.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Defra.PhaImportNotifications.Api.Metrics;
+
+[ExcludeFromCodeCoverage]
+public class MetricsMiddleware(RequestMetrics requestMetrics) : IMiddleware
+{
+    private static readonly string[] s_startsWith = ["/apple-", "/favicon", "/redoc", "/.well-known/openapi"];
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        var startingTimestamp = TimeProvider.System.GetTimestamp();
+
+        await next(context);
+
+        var routeMetadata = context.GetEndpoint()?.Metadata.GetMetadata<IRouteDiagnosticsMetadata>();
+        var path = routeMetadata?.Route;
+
+        if (IgnoreRequest(path))
+            return;
+
+        requestMetrics.RequestCompleted(
+            path!,
+            context.Request.Method,
+            context.Response.StatusCode,
+            TimeProvider.System.GetElapsedTime(startingTimestamp)
+        );
+    }
+
+    private static bool IgnoreRequest(string? path) =>
+        !string.IsNullOrWhiteSpace(path) && s_startsWith.Any(path.StartsWith);
+}

--- a/src/Api/Metrics/RequestMetrics.cs
+++ b/src/Api/Metrics/RequestMetrics.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Amazon.CloudWatch.EMF.Model;
+
+namespace Defra.PhaImportNotifications.Api.Metrics;
+
+public class RequestMetrics
+{
+    private readonly Counter<long> _requestsReceived;
+    private readonly Histogram<double> _requestDuration;
+
+    private static class RequestTags
+    {
+        public const string Method = nameof(Method);
+        public const string Path = nameof(Path);
+        public const string StatusCode = nameof(StatusCode);
+    }
+
+    public RequestMetrics(IMeterFactory meterFactory)
+    {
+        var meter = meterFactory.Create(MetricsConstants.MetricNames.MeterName);
+
+        _requestsReceived = meter.CreateCounter<long>("http.server.request", nameof(Unit.COUNT), "Count of Requests");
+
+        _requestDuration = meter.CreateHistogram<double>(
+            "http.server.request.duration",
+            nameof(Unit.MILLISECONDS),
+            "Duration of request"
+        );
+    }
+
+    public void RequestCompleted(string requestPath, string httpMethod, int statusCode, TimeSpan duration)
+    {
+        _requestsReceived.Add(1, BuildTags(requestPath, httpMethod, statusCode));
+        _requestDuration.Record(duration.TotalMilliseconds, BuildTags(requestPath, httpMethod, statusCode));
+    }
+
+    private static TagList BuildTags(string requestPath, string httpMethod, int statusCode) =>
+        new()
+        {
+            { RequestTags.Path, requestPath },
+            { RequestTags.Method, httpMethod },
+            { RequestTags.StatusCode, statusCode },
+        };
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Defra.PhaImportNotifications.Api.Configuration;
 using Defra.PhaImportNotifications.Api.Endpoints.ImportNotifications;
 using Defra.PhaImportNotifications.Api.Extensions;
+using Defra.PhaImportNotifications.Api.Metrics;
 using Defra.PhaImportNotifications.Api.OpenApi;
 using Defra.PhaImportNotifications.Api.Services;
 using Defra.PhaImportNotifications.Api.Utils;
@@ -154,6 +155,10 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
             }
         );
     });
+
+    builder.Services.AddSingleton<RequestMetrics>();
+    builder.Services.AddTransient<MetricsMiddleware>();
+
     builder.Services.AddHttpClient();
     builder.Services.AddHeaderPropagation(options =>
     {
@@ -197,6 +202,8 @@ static WebApplication BuildWebApplication(WebApplicationBuilder builder)
 {
     var app = builder.Build();
 
+    app.UseEmfExporter(builder.Environment.ApplicationName);
+    app.UseMiddleware<MetricsMiddleware>();
     app.UseHeaderPropagation();
     app.UseAuthentication();
     app.UseAuthorization();

--- a/src/Api/Properties/launchSettings.json
+++ b/src/Api/Properties/launchSettings.json
@@ -7,7 +7,8 @@
       "applicationUrl": "http://localhost:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "ENVIRONMENT": "Local"
+        "ENVIRONMENT": "Local",
+        "AWS_EMF_ENVIRONMENT": "Local"
       }
     }
   }

--- a/src/Api/appsettings.IntegrationTests.json
+++ b/src/Api/appsettings.IntegrationTests.json
@@ -1,4 +1,5 @@
 {
+  "AWS_EMF_ENABLED" : false,
   "OpenApi": {
     "Host": "integration-test-host"
   },

--- a/tests/Api.Unit/Metrics/RequestMetricsTests.cs
+++ b/tests/Api.Unit/Metrics/RequestMetricsTests.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics.Metrics;
+using Defra.PhaImportNotifications.Api.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+
+namespace Defra.PhaImportNotifications.Tests.Api.Unit.Metrics;
+
+public class RequestMetricsTests
+{
+    [Fact]
+    public void When_message_received_Then_counter_is_incremented()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddMetrics();
+        var mf = serviceCollection.BuildServiceProvider().GetRequiredService<IMeterFactory>();
+
+        var messagesReceivedCollector = new MetricCollector<long>(
+            mf,
+            MetricsConstants.MetricNames.MeterName,
+            "http.server.request"
+        );
+
+        var messagesReceivedDurationCollector = new MetricCollector<double>(
+            mf,
+            MetricsConstants.MetricNames.MeterName,
+            "http.server.request.duration"
+        );
+
+        var metrics = new RequestMetrics(mf);
+
+        metrics.RequestCompleted("TestMessage1", "/test-request-path-1", 200, TimeSpan.FromSeconds(2));
+
+        var receivedMeasurements = messagesReceivedCollector.GetMeasurementSnapshot();
+
+        receivedMeasurements.Count.Should().Be(1);
+        receivedMeasurements[0].Value.Should().Be(1);
+
+        receivedMeasurements[0].ContainsTags("Path").Should().BeTrue();
+        receivedMeasurements[0].Tags["Path"].Should().Be("TestMessage1");
+
+        receivedMeasurements[0].ContainsTags("Method").Should().BeTrue();
+        receivedMeasurements[0].Tags["Method"].Should().Be("/test-request-path-1");
+
+        receivedMeasurements[0].ContainsTags("StatusCode").Should().BeTrue();
+        receivedMeasurements[0].Tags["StatusCode"]?.Should().Be(200);
+
+        var receivedDurationMeasurements = messagesReceivedDurationCollector.GetMeasurementSnapshot();
+
+        receivedDurationMeasurements.Count.Should().Be(1);
+        receivedDurationMeasurements[0].Value.Should().Be(2000);
+    }
+}

--- a/tests/PhaImportNotifcations.Tests.csproj
+++ b/tests/PhaImportNotifcations.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />


### PR DESCRIPTION
Publish http server metrics to CloudWatch using EMF (Embedded metric format).