### PR TITLE
PHAIN-263: Update development appsettings

### DIFF
--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -25,7 +25,11 @@
   "Acl": {
     "Clients": {
       "LocalDev": {
-        "Bcps": ["bcp1", "bcp2"],
+        "Bcps": [
+          "bcp1",
+          "bcp2",
+          "GBTEEP1"
+        ],
         "ChedTypes": ["*"]
       }
     },


### PR DESCRIPTION
- Update development appsettings to allow development access to `GBTEEP1` BCP as the majority of scenarios in [trade-imports-data-api-stub](https://github.com/DEFRA/trade-imports-data-api-stub) are configured for this particular BCP.